### PR TITLE
SC-6293 - adds learn store permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ## Unreleased
 
+- SC-6239 - adds lernstore permmission
 - SC-6628 Changing backend url endpoint while analog consenting
 
 ## [24.5.0] - 2020-09-14

--- a/docs/1-Tutorials/PagePermissionCheck.md
+++ b/docs/1-Tutorials/PagePermissionCheck.md
@@ -2,7 +2,7 @@
 
 Sometimes you wan't to prevent access to pages if the user doesn't have some permissions. Therefore you can use the `meta.requiredPermissions` attribute.
 
-The simple syntax would be to add the following code to your page:
+a) The simple syntax would be to add the following code to your page:
 
 ```vue{4}
 <script>
@@ -16,7 +16,7 @@ export default {
 
 In this case, the current user must have all the defined permissions.
 
-If you wan't more controle you can pass an Object:
+b) If you want more control, you can pass an Object:
 
 ```vue{4-7}
 <script>
@@ -32,5 +32,30 @@ export default {
 ```
 
 This way, you can define if the user must have all defined permissions (`operator: "AND"`) or if it is enough to fullfill one of the defined permissions (`operator: "OR"`).
+
+c) Finally, if you want to combine the permissions, you can pass in an array of objects:
+
+```vue{4-7}
+<script>
+export default {
+	meta: {
+		requiredPermissions: [
+			{
+				operator: "NOT",
+				permissions: ["PERMISSION_A", "PERMISSION_B"],
+			},
+			{
+				operator: "AND",
+				permissions: ["PERMISSION_A", "PERMISSION_B"],
+			},
+			{
+				operator: "OR",
+				permissions: ["PERMISSION_A", "PERMISSION_B"],
+			},
+		],
+	},
+};
+</script>
+```
 
 The actual permission-check logic is defined in `@middleware/permission-check.js`.

--- a/src/components/organisms/LernstoreDetailView.vue
+++ b/src/components/organisms/LernstoreDetailView.vue
@@ -140,6 +140,18 @@ import { getMetadataAttribute } from "@utils/helpers";
 const DEFAULT_AUTHOR = "admin";
 
 export default {
+	meta: {
+		requiredPermissions: [
+			{
+				operator: "AND",
+				permissions: ["LERNSTORE_VIEW"],
+			},
+			{
+				operator: "NOT",
+				permissions: ["LERNSTORE_HIDE"],
+			},
+		],
+	},
 	components: {
 		BaseLink,
 		AddContentButton,

--- a/src/pages/content/_id/index.vue
+++ b/src/pages/content/_id/index.vue
@@ -8,6 +8,18 @@
 import LernstoreDetailView from "@components/organisms/LernstoreDetailView";
 
 export default {
+	meta: {
+		requiredPermissions: [
+			{
+				operator: "AND",
+				permissions: ["LERNSTORE_VIEW"],
+			},
+			{
+				operator: "NOT",
+				permissions: ["LERNSTORE_HIDE"],
+			},
+		],
+	},
 	components: {
 		LernstoreDetailView,
 	},

--- a/src/pages/content/index.vue
+++ b/src/pages/content/index.vue
@@ -73,6 +73,18 @@ import BaseButton from "../../components/base/BaseButton";
 import ContentInitialState from "@components/molecules/ContentInitialState";
 
 export default {
+	meta: {
+		requiredPermissions: [
+			{
+				operator: "AND",
+				permissions: ["LERNSTORE_VIEW"],
+			},
+			{
+				operator: "NOT",
+				permissions: ["LERNSTORE_HIDE"],
+			},
+		],
+	},
 	components: {
 		BaseButton,
 		ContentSearchbar,

--- a/src/utils/sidebarBaseItems.js
+++ b/src/utils/sidebarBaseItems.js
@@ -71,7 +71,13 @@ export default [
 		icon: "newspaper-o",
 	},
 	{ title: "Termine", href: "/calendar", icon: "table" },
-	{ title: "Lern-store", href: "/content", icon: "search" },
+	{
+		title: "Lern-store",
+		href: "/content",
+		icon: "search",
+		permission: "LERNSTORE_VIEW",
+		excludedPermission: "LERNSTORE_HIDE",
+	},
 	{
 		title: "Add-Ons",
 		href: "/addons",

--- a/tests/middleware/permission-check.unit.js
+++ b/tests/middleware/permission-check.unit.js
@@ -66,6 +66,19 @@ describe("@middleware/permission-check", () => {
 		expect(await permissionCheck(mockContext)).toBe(true);
 	});
 
+	it(`grants access using advanced "NOT" syntax`, async () => {
+		const mockContext = getMockContext({
+			store: getMockStore({ permissions: ["PERMISSION_A", "PERMISSION_B"] }),
+			route: getMockRoute({
+				operator: "NOT",
+				permissions: ["PERMISSION_B"],
+			}),
+		});
+		await expect(permissionCheck(mockContext)).rejects.toThrow(
+			new Error("error.401")
+		);
+	});
+
 	it("grants Access if no permissions are required AND user exists", async () => {
 		const mockContext = getMockContext({
 			store: getMockStore({ permissions: ["PERMISSION_A"] }),


### PR DESCRIPTION
# Description

There was the need to dissallow students from Schleswig-Holstein access to the Lern-Store. Since there is no way to grant access to some students, but not others, the proposed solution is using an additional role and extends the permission system to allow for negative permission checks. I.e. access is granted if users have LERNSTORE_VIEW permission and don't have LERNSTORE_DENY permission.
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests

- https://ticketsystem.hpi-schul-cloud.org/browse/SC-6293
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/2170
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/1718

## Changes

Permissions can be checked for combinations of conditions and now supports NOT operator. 
For details check docs/1-Tutorials/PagePermissionCheck.md

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
