### PR TITLE
Quickfix - Remove content from routes, which causes tests to fail

### DIFF
--- a/src/serverMiddleware/routes.js
+++ b/src/serverMiddleware/routes.js
@@ -20,7 +20,6 @@ const routes = [
 	// `^/administration/teachers/?$`,
 	// `^/administration/teachers/new/?$`,
 	`^/login-instances/?`,
-	`^/content/`,
 	//`^/calendar/?`,
 	`^/error/`,
 	`^/imprint/?`,

--- a/src/store/calendar.js
+++ b/src/store/calendar.js
@@ -1,14 +1,14 @@
 import serviceTemplate from "@utils/service-template";
 import mergeDeep from "@/utils/merge-deep";
-const baseUrl = "calendar"
+const baseUrl = "calendar";
 const base = serviceTemplate(baseUrl);
 
-const module = mergeDeep (base, {
+const module = mergeDeep(base, {
 	actions: {
 		removeDate: async function (ctx, payload) {
 			await this.$axios.$delete("/" + baseUrl + "/" + payload.id);
-		}
-	}
+		},
+	},
 });
 
 export default module;


### PR DESCRIPTION
Should fix earlier cowboy-commits by Dr. Jan Renz which broke the integration tests in all repos 🤠

Here's the tl/dr: the integration tests which click around in the left menu fail if they click on a top-level nuxt page, since in nuxt, the links in the navigation bar don't have the `title` attribute. Until now, no top-level nuxt page was accessible in the navigation (content is behind a feature flag that the tests don't set yet). With https://github.com/hpi-schul-cloud/nuxt-client/commit/312ee52f60474efe1f4fde497ff993fd2105f176#diff-cbb87fee2982fe656d5592050d3605b9b320d91dd94fb3ffd8a1a02e70e3a91dR23, the content route was introduced without feature-flag, which broke the tests.