### PR TITLE
Feature/SC-7447 - add warning text leaving sc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Changed
 
+- SC-7447 Add warning text for links when leaving the schul-cloud platform
 - SC-6060 Updated caniuse-lite
 
 ## 25.2.0

--- a/locale/de.json
+++ b/locale/de.json
@@ -365,6 +365,8 @@
 	"pages.content.label.select": "Auswählen",
 	"pages.content.label.selected": "Aktiv",
 	"pages.content.material.toMaterial": "Zum Inhalt",
+	"pages.content.material.leavePageWarningMain": "Hinweis: Beim Klicken des Links verlassen Sie das Angebot der Schul-Cloud",
+	"pages.content.material.leavePageWarningFooter": "Die Nutzung dieser Angebote unterliegt gegebenenfalls anderen rechtlichen Bedingungen. Bitte schauen Sie daher in die Datenschutzerklärung des externen Anbieters!",
 	"pages.content.notification.errorMsg": "Material konnte nicht hinzugefügt werden",
 	"pages.content.notification.lernstoreNotAvailable": "Lernstore ist nicht verfügbar",
 	"pages.content.notification.loading": "Material wird hinzugefügt",

--- a/locale/en.json
+++ b/locale/en.json
@@ -352,6 +352,8 @@
 	"pages.content.label.deselect": "Remove",
 	"pages.content.label.select": "Select",
 	"pages.content.label.selected": "Active",
+	"pages.content.material.leavePageWarningMain": "Note: Clicking the link will take you away from Schul-Cloud",
+	"pages.content.material.leavePageWarningFooter": "The use of these offers may be subject to other legal conditions. Therefore, please take a look at the privacy policy of the external provider!",
 	"pages.content.material.toMaterial": "Material",
 	"pages.content.notification.errorMsg": "Something has gone wrong. Material could not be added.",
 	"pages.content.notification.lernstoreNotAvailable": "Learning store is not available",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31418,8 +31418,7 @@
 						"is-number": {
 							"version": "7.0.0",
 							"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-							"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-							"optional": true
+							"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
 						},
 						"normalize-path": {
 							"version": "3.0.0",
@@ -31440,7 +31439,6 @@
 							"version": "5.0.1",
 							"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 							"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-							"optional": true,
 							"requires": {
 								"is-number": "^7.0.0"
 							}

--- a/src/components/organisms/LernstoreDetailView.vue
+++ b/src/components/organisms/LernstoreDetailView.vue
@@ -59,6 +59,7 @@
 					<base-button
 						v-if="isMerlinContent"
 						design="outline"
+						class="content-button"
 						@click="
 							() => {
 								goToMerlinContent(merlinTokenReference);
@@ -72,11 +73,21 @@
 						v-else
 						design="outline"
 						:href="downloadUrl"
+						class="content-button"
 						target="_blank"
 					>
 						<base-icon source="custom" icon="open_new_window" />
 						{{ $t("pages.content.material.toMaterial") }}
 					</base-button>
+					<!-- This will be replaced with Modal -->
+					<div class="external-content-warning">
+						<p class="text-s external-content-title">
+							{{ $t("pages.content.material.leavePageWarningMain") }}
+						</p>
+						<p class="text-xs">
+							{{ $t("pages.content.material.leavePageWarningFooter") }}
+						</p>
+					</div>
 				</div>
 				<!-- eslint-disable vue/no-v-html -->
 				<div class="description text-wrap" v-html="description"></div>
@@ -389,6 +400,19 @@ $tablet-portrait-width: 768px;
 		.content-container {
 			width: 80%;
 			margin-top: var(--space-md);
+		}
+
+		.external-content-warning {
+			color: var(--color-danger);
+
+			.external-content-title {
+				margin-top: var(--space-md);
+				font-weight: var(--font-weight-bold);
+			}
+		}
+
+		.content-button {
+			width: 100%;
 		}
 
 		.actions {


### PR DESCRIPTION
# Description
## Links to Tickets or other pull requests
Ticket: https://ticketsystem.hpi-schul-cloud.org/browse/SC-7447
Client: https://github.com/hpi-schul-cloud/schulcloud-client/compare/Feature/SC-7447-add-warning-text-leaving-sc?expand=1
Nuxt: https://github.com/hpi-schul-cloud/nuxt-client/compare/Feature/SC-7447-add-warning-text-leaving-sc?expand=1

The pr adds a warning text required by stake holders to warn users when they leave schul-cloud.
## Approval for review
- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

<img width="807" alt="client" src="https://user-images.githubusercontent.com/32653149/97001444-a83f3a80-1538-11eb-896c-62bf757d5330.png">
<img width="479" alt="nuxt" src="https://user-images.githubusercontent.com/32653149/97001450-a9706780-1538-11eb-9784-cb83e8b37c24.png">
