### PR TITLE
SC-7447---quickfix/add-brandenburg-name-to-warning-text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Changed
 
-- SC-7447 Add warning text for links when leaving the schul-cloud platform
+- SC-7447 Add warning text for links when leaving the schul-cloud platform.
 - SC-6060 Updated caniuse-lite
 
 ## 25.2.0

--- a/locale/de.json
+++ b/locale/de.json
@@ -365,7 +365,7 @@
 	"pages.content.label.select": "Auswählen",
 	"pages.content.label.selected": "Aktiv",
 	"pages.content.material.toMaterial": "Zum Inhalt",
-	"pages.content.material.leavePageWarningMain": "Hinweis: Beim Klicken des Links verlassen Sie das Angebot der Schul-Cloud",
+	"pages.content.material.leavePageWarningMain": "Hinweis: Beim Klicken des Links verlassen Sie das Angebot der Schul-Cloud Brandenburg.",
 	"pages.content.material.leavePageWarningFooter": "Die Nutzung dieser Angebote unterliegt gegebenenfalls anderen rechtlichen Bedingungen. Bitte schauen Sie daher in die Datenschutzerklärung des externen Anbieters!",
 	"pages.content.notification.errorMsg": "Material konnte nicht hinzugefügt werden",
 	"pages.content.notification.lernstoreNotAvailable": "Lernstore ist nicht verfügbar",

--- a/locale/en.json
+++ b/locale/en.json
@@ -352,7 +352,7 @@
 	"pages.content.label.deselect": "Remove",
 	"pages.content.label.select": "Select",
 	"pages.content.label.selected": "Active",
-	"pages.content.material.leavePageWarningMain": "Note: Clicking the link will take you away from Schul-Cloud",
+	"pages.content.material.leavePageWarningMain": "Note: Clicking the link will take you away from Schul-Cloud Brandenburg.",
 	"pages.content.material.leavePageWarningFooter": "The use of these offers may be subject to other legal conditions. Therefore, please take a look at the privacy policy of the external provider!",
 	"pages.content.material.toMaterial": "Material",
 	"pages.content.notification.errorMsg": "Something has gone wrong. Material could not be added.",


### PR DESCRIPTION
[Nuxt pr](https://github.com/hpi-schul-cloud/nuxt-client/compare/SC-7447---quickfix/add-brandenburg-name-to-warning-text?expand=1)
[Client pr](https://github.com/hpi-schul-cloud/schulcloud-client/compare/Feature/SC-7447-add-brandenburg-to-info-text?expand=1)

**BEFORE:** "pages.content.material.leavePageWarningMain": "Hinweis: Beim Klicken des Links verlassen Sie das Angebot der Schul-Cloud.",
**AFTER.** "pages.content.material.leavePageWarningMain": "Hinweis: Beim Klicken des Links verlassen Sie das Angebot der Schul-Cloud Brandenburg.",

name of the state is added at end of text.

[Duplicated ](https://github.com/hpi-schul-cloud/nuxt-client/pull/1461)