### PR TITLE
SC-7557 - fixes lernstore modal width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 ### Fixed
 
 - SC-6293 - loads full permissions for user, e.g. school permission too, not just the ones on his role
+- SC-7557 - fixes lernstore modal width
 
 ### Changed
 

--- a/src/components/molecules/AddContentModal.vue
+++ b/src/components/molecules/AddContentModal.vue
@@ -171,7 +171,7 @@ export default {
 
 <style lang="scss" scoped>
 .modal {
-	width: 300px;
+	width: 100%;
 }
 .content-modal {
 	&__body {


### PR DESCRIPTION
# Description

fixes lernstore modal width

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/SC-7557

## Changes

- changed as 300px width of the lernstore modal for adding content to 100%


## Screenshots of UI changes

<img width="1792" alt="Screenshot 2020-11-13 at 15 10 04" src="https://user-images.githubusercontent.com/2567952/99080952-541cf880-25c2-11eb-9935-6c6a153bb0ca.png">


## Approval for review

- [X] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
