### PR TITLE
SC-6992 - changed header name for login-instances page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ### Fixed
 
+- SC-7845 - fixed header tab name on login-instances page
 - SC-7845 - fixed the changelog github action
 - SC-6293 - loads full permissions for user, e.g. school permission too, not just the ones on his role
 - SC-7557 - fixes lernstore modal width

--- a/src/pages/login-instances/index.vue
+++ b/src/pages/login-instances/index.vue
@@ -71,6 +71,11 @@ export default {
 			return this.$mq === "tablet";
 		},
 	},
+	head() {
+		return {
+			title: "HPI Schul-Cloud",
+		}
+	}
 };
 </script>
 


### PR DESCRIPTION
# Description
change tab name of login-instances page

## Links to Tickets or other pull requests

- https://ticketsystem.schul-cloud.org/browse/SC-6992

## Screenshots of UI changes
![image](https://user-images.githubusercontent.com/40116220/99974660-8b995b00-2da1-11eb-88cf-48de0524da8e.png)
