### PR TITLE
SC-8433 - changed text in Lern-Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 ### Changed
 
 - SC-8356 - authenticate docker hub requests
+- SC-8433 - update text in Lern-Store
 
 ## 25.5.1
 

--- a/locale/de.json
+++ b/locale/de.json
@@ -352,7 +352,7 @@
 	"pages.administration.teachers.new.title": "Lehrer:in hinzufügen",
 	"pages.content._id.addToTopic": "Hinzufügen zu",
 	"pages.content._id.metadata.author": "Autor",
-	"pages.content._id.metadata.createdAt": "erstellt am",
+	"pages.content._id.metadata.createdAt": "abgerufen am",
 	"pages.content._id.metadata.noTags": "Keine Tags",
 	"pages.content._id.metadata.provider": "Herausgeber",
 	"pages.content._id.metadata.updatedAt": "zuletzt geändert am",

--- a/locale/en.json
+++ b/locale/en.json
@@ -377,7 +377,7 @@
 	"pages.administration.ldapEdit.validation.url": "Please match a valid URL format",
 	"pages.content._id.addToTopic": "To be added to",
 	"pages.content._id.metadata.author": "Author",
-	"pages.content._id.metadata.createdAt": "Created on",
+	"pages.content._id.metadata.createdAt": "requested at",
 	"pages.content._id.metadata.noTags": "No tags",
 	"pages.content._id.metadata.provider": "Publisher",
 	"pages.content._id.metadata.updatedAt": "Last modified on",


### PR DESCRIPTION
# Description

Change the text from "created at" to "requested at".
In German: change from "erstellt am" to "abgerufen am".

## Links to Tickets or other pull requests

- https://ticketsystem.schul-cloud.org/browse/SC-8433


## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [ ] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
