### PR TITLE
SC-8577 - hotfix/roles section validation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`
 
+## 25.5.2
+
+### Fixed
+
+- SC-8577 - fixes the LDAP config roles section validation to not require it when user attribute is toggled
+
 ## 25.5.1
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-nuxt",
-	"version": "25.5.1",
+	"version": "25.5.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-nuxt",
-	"version": "25.5.2",
+	"version": "25.5.16",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-nuxt",
-	"version": "25.5.1",
+	"version": "25.5.2",
 	"description": "The next Level of HPI Schul-Cloud",
 	"author": "HPI Schul-Cloud",
 	"private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "schulcloud-nuxt",
-	"version": "25.5.2",
+	"version": "25.5.16",
 	"description": "The next Level of HPI Schul-Cloud",
 	"author": "HPI Schul-Cloud",
 	"private": true,

--- a/src/components/organisms/Ldap/LdapRolesSection.unit.js
+++ b/src/components/organisms/Ldap/LdapRolesSection.unit.js
@@ -40,8 +40,8 @@ describe("@components/organisms/LdapRolesSection", () => {
 		const wrapper = mount(LdapRolesSection, {
 			...createComponentMocks({ i18n: true }),
 			propsData: {
-				// validations are only active when groupOption !== group
-				value: { ...ldapConfigData, groupOption: "not group" },
+				// validations are only active when groupOption === group
+				value: { ...ldapConfigData, groupOption: "group" },
 			},
 		});
 		expect(wrapper.vm.$v).not.toBeUndefined();
@@ -51,8 +51,8 @@ describe("@components/organisms/LdapRolesSection", () => {
 		const wrapper = mount(LdapRolesSection, {
 			...createComponentMocks({ i18n: true }),
 			propsData: {
-				// validations are only active when groupOption !== group
-				value: { ...ldapConfigData, groupOption: "not group" },
+				// validations are only active when groupOption === group
+				value: { ...ldapConfigData, groupOption: "group" },
 			},
 		});
 		// default props values are valid so expect this assertion to succeed
@@ -64,8 +64,8 @@ describe("@components/organisms/LdapRolesSection", () => {
 			...createComponentMocks({ i18n: true }),
 			propsData: {
 				value: {
-					// validations are only active when groupOption !== group
-					groupOption: "not ldap group",
+					// validations are only active when groupOption === group
+					groupOption: "group",
 					member: "",
 					student: "invalid",
 					teacher: "invalid",
@@ -80,8 +80,8 @@ describe("@components/organisms/LdapRolesSection", () => {
 	it("invalid validation is true when any of the input values are invalid", async () => {
 		const ldapConfigDataTestSpecific = {
 			...ldapConfigData,
-			// validations are only active when groupOption !== group
-			groupOption: "not ldap group",
+			// validations are only active when groupOption === group
+			groupOption: "group",
 		};
 		const wrapper = mount(LdapRolesSection, {
 			...createComponentMocks({ i18n: true }),
@@ -99,17 +99,19 @@ describe("@components/organisms/LdapRolesSection", () => {
 			},
 		});
 
-		const inputMember = wrapper.find("input[data-testid=ldapDataRolesMember]");
-		expect(inputMember.exists()).toBe(true);
+		const inputStudent = wrapper.find(
+			"input[data-testid=ldapDataRolesStudent]"
+		);
+		expect(inputStudent.exists()).toBe(true);
 
-		inputMember.setValue("");
-		inputMember.trigger("blur");
+		inputStudent.setValue("not valid");
+		inputStudent.trigger("blur");
 
-		expect(inputMember.element.value).toBe("");
+		expect(inputStudent.element.value).toBe("not valid");
 		expect(wrapper.vm.$v.$invalid).toBe(true);
 		await wrapper.vm.$nextTick();
 		const errorMessageComponent = wrapper.find(
-			"div[data-testid='ldapDataRolesMember'] .info.error"
+			"div[data-testid='ldapDataRolesStudent'] .info.error"
 		);
 		expect(errorMessageComponent.exists()).toBeTrue();
 	});
@@ -135,8 +137,8 @@ describe("@components/organisms/LdapRolesSection", () => {
 
 	it("invalid error message is displayed only after the blur event, even if originally invalid props were passed through", async () => {
 		const ldapConfigDataTestSpecific = {
-			// validations are only active when groupOption !== group
-			groupOption: "not ldap group",
+			// validations are only active when groupOption === group
+			groupOption: "group",
 			member: "",
 			student: "invalid",
 			teacher: "invalid",
@@ -160,20 +162,20 @@ describe("@components/organisms/LdapRolesSection", () => {
 		});
 
 		let errorMessageComponent = wrapper.find(
-			"div[data-testid='ldapDataRolesMember'] .info.error"
+			"div[data-testid='ldapDataRolesStudent'] .info.error"
 		);
 		expect(wrapper.vm.$v.$invalid).toBe(true);
 		expect(errorMessageComponent.exists()).toBeFalse();
 
-		const inputMember = wrapper.find("input[data-testid=ldapDataRolesMember]");
+		const inputMember = wrapper.find("input[data-testid=ldapDataRolesStudent]");
 		expect(inputMember.exists()).toBe(true);
-		expect(inputMember.element.value).toBe(ldapConfigDataTestSpecific.member);
+		expect(inputMember.element.value).toBe(ldapConfigDataTestSpecific.student);
 
 		inputMember.trigger("blur"); // without this the error is not displayed
 
 		await wrapper.vm.$nextTick();
 		errorMessageComponent = wrapper.find(
-			"div[data-testid='ldapDataRolesMember'] .info.error"
+			"div[data-testid='ldapDataRolesStudent'] .info.error"
 		);
 		expect(errorMessageComponent.exists()).toBeTrue();
 	});

--- a/src/components/organisms/Ldap/LdapRolesSection.vue
+++ b/src/components/organisms/Ldap/LdapRolesSection.vue
@@ -176,7 +176,7 @@ export default {
 		},
 	},
 	validations() {
-		if (this.groupOption !== "group") {
+		if (this.groupOption === "group") {
 			return {
 				value: {
 					member: { required },


### PR DESCRIPTION
# Description
Fixes the client-side validation for the roles section
<!--
  This is a template to add as many information as possible to the pull request, to help reviewer and as a checklist for you. Points to remember are set in the comments, please read and keep them in mind:

    - Code should be self-explanatory and share your knowledge with others
    - Document code that is not self-explanatory
    - Think about bugs and keep security in mind
    - Write tests (Unit and Integration), also for error cases
    - Main logic should hidden behind the api, never trust the client
    - Visible changes should be discussed with the UX-Team from the begining of development; they also have to accept them at the end
    - Keep the changelog up-to-date
    - Leave the code cleaner than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/SC-8577

<!--
Base links to copy
- https://github.com/schul-cloud/schulcloud-server/pull/????
- https://ticketsystem.schul-cloud.org/browse/SC-????
-->

## Changes

<!--
  What will the PR change?
  Why are the changes requiered?
  Short notice if a ticket exists, more detailed if not
-->

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

<!--
  Notice about:
  - model changes
  - logging of user data
  - right changes
  - and other user data stuff
  If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
  Keep in mind to changes to seed data, if changes are done by migration scripts.
  Changes to the infrastructure have to discussed with the devops

  This point should includes following informations:
  - What is required for deployment?
  - Envirement variables like FEATURE_XY=true
  - Migration scripts to run, other requirements
-->

## New Repos, NPM pakages or vendor scripts

<!--
  Keep in mind the stability, performance, activity and author.

  Describe why it is needed.
-->

## Screenshots of UI changes

<!--
  only needed for visual changes

  If visual changes exist, work together with UI/UX from beginning/ping UX with final PR
-->

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.

> Notice: Please remove the WIP label if the PR is ready to review, otherwise nobody will review it.

### Link to Definiton of Done

More and detailed information on the _definition of done_ can be found [on Confluence](https://docs.schul-cloud.org/pages/viewpage.action?pageId=92831762)
