### PR TITLE
OPS-2574 - Removeing autodeployed branches for developers if branch deleted

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -1,0 +1,17 @@
+---
+name: Clean Deployment
+
+on: delete
+
+jobs:
+  dispatch-clean:
+    if: github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: hpi-schul-cloud/dof_app_deploy
+          event-type: dev-clean
+          client-payload: '{"branch": "${{ github.event.ref }}" }'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 ### Added
 
 - SC-9090 - implemented a loading state in the service-template
+- OPS-2574 - Removeing autodeployed branches for developers if branch deleted
 
 ### Changed
 


### PR DESCRIPTION
# Description
OPS-2574 - Removeing autodeployed branches for developers if branch deleted

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/OPS-2574

## Changes

Removeing autodeployed branches for developers if branch deleted

## Datasecurity <sub><sup>details [on Confluence](https://docs.schul-cloud.org/x/2S3GBg)</sup></sub>

## Deployment


## New Repos, NPM pakages or vendor scripts

## Screenshots of UI changes

<!--
- For UI changes, insert screenshots here.
- Has it been reviewed by a UX colleague?
-->

## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
