### PR TITLE
BC-37 - BC-56 - reduce resource consumption for deployed nuxtclient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ## Unreleased
 
+ - BC-37 - BC-56 - reduce resource consumption for deployed nuxtclient
+
 ## [26.9.1] - 2021-08-16
 
 - SC-9192 - fix add material to course lesson and load exsiting ldap config for modification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Allowed Types of change: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `
 
 ## Unreleased
 
- - BC-37 - BC-56 - reduce resource consumption for deployed nuxtclient
+- BC-37 - BC-56 - reduce resource consumption for deployed nuxtclient
 
 ## [26.9.1] - 2021-08-16
 

--- a/ansible/roles/nuxt-client/templates/deployment.yml.j2
+++ b/ansible/roles/nuxt-client/templates/deployment.yml.j2
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: nuxtclient
 spec:
-  replicas: {{ NUXTCLIENT_REPLICAS|default("2", true) }}
+  replicas: {{ NUXTCLIENT_REPLICAS|default("1", true) }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -66,11 +66,11 @@ spec:
           periodSeconds: 5
         resources:
           limits:
-            cpu: "2000m"
-            memory: "4Gi"
+            cpu: {{ NUXTCLIENT_CPU_LIMITS|default("2000m", true) }}
+            memory: {{ NUXTCLIENT_MEMORY_LIMITS|default("4Gi", true) }}
           requests:
-            cpu: "1000m"
-            memory: "4Gi"
+            cpu: {{ NUXTCLIENT_CPU_REQUESTS|default("100m", true) }}
+            memory: {{ NUXTCLIENT_MEMORY_REQUESTS|default("128Mi", true) }}
       volumes:
       - name: http-headers
         configMap:


### PR DESCRIPTION
# Short Description
Reduce resource consumption for deployed nuxtclient.

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/BC-37
https://ticketsystem.hpi-schul-cloud.org/browse/BC-56

## Changes
 Make CPU and memory resource consumption configurable.
 Set the default for memory to be between 128mb and 4gb.
 Set the default pod count to 1 pod

## Data-security <sub><sup>details [on Confluence](https://docs.hpi-schul-cloud.org/x/2S3GBg)</sup></sub>

<!--
Please note here about:
- any data model changes
- any changes about logging of user data
- any changes about permissions
- user input, authentication and other user data related things
If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
Keep in mind to changes to seed data, if changes are done by migration scripts.
Changes to the infrastructure have to discussed with the devops.
This information should be also in corresponding ticket, and collected in release deployment ticket.

This point should includes following information:
- What else is required for its deployment?
- Environment variables like FEATURE_XY=true
- Are there any migration scripts to be run?
-->

## New Repos, NPM packages or vendor scripts

<!--
- Keep in mind the stability, performance, activity and author.
- Describe why it is needed.
-->

## Screenshots of UI changes

<!--
- For UI changes, insert screenshots here.
- Has it been reviewed by a UX colleague?
-->

## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
