### PR TITLE
BC-1230 - change mode for configmaps to apply

### DIFF
--- a/ansible/roles/nuxt-client-core/tasks/main.yml
+++ b/ansible/roles/nuxt-client-core/tasks/main.yml
@@ -9,12 +9,14 @@
       kubeconfig: ~/.kube/config 
       namespace: "{{ NAMESPACE }}"
       template: configmap.yml.j2
+      apply: yes
       
   - name: Configmap File
     kubernetes.core.k8s:
       kubeconfig: ~/.kube/config 
       namespace: "{{ NAMESPACE }}"
       template: configmap-files.yml.j2
+      apply: yes
       
   - name: Deployment
     kubernetes.core.k8s:


### PR DESCRIPTION
# Description
Change the mode for the configmaps at the ansible roles to apply for configmaps and secrets

## Links to Tickets or other pull requests
https://ticketsystem.hpi-schul-cloud.org/browse/BC-1230
hpi-schul-cloud/dof_app_deploy#111
hpi-schul-cloud/antivirus_check_service#20
hpi-schul-cloud/superhero-dashboard#157
hpi-schul-cloud/schulcloud-server#3311
hpi-schul-cloud/schulcloud-client#2759
hpi-schul-cloud/schulcloud-calendar#109

## Approval for review

- [x] All points were discussed with the ticket creator, support-team or product owner. The code upholds all quality guidelines from the PR-template.
