### PR TITLE
BC-2378 - Custom Icon Libraries and MDI Icons

### DIFF
--- a/vue3_poc/src/pages/HomePage.vue
+++ b/vue3_poc/src/pages/HomePage.vue
@@ -1,7 +1,12 @@
 <template>
 	<div>
 		<div>
-			<h2 class="text-h2">{{ persistentValue }} <v-icon>mdi-home</v-icon></h2>
+			<h2 class="text-h2">
+				{{ persistentValue }} <v-icon>{{ mdiHome }}</v-icon
+				><v-icon>{{
+					"M7 15h7v2H7zm0-4h10v2H7zm0-4h10v2H7zm12-4h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-.14 0-.27.01-.4.04a2.008 2.008 0 0 0-1.44 1.19c-.1.23-.16.49-.16.77v14c0 .27.06.54.16.78s.25.45.43.64c.27.27.62.47 1.01.55.13.02.26.03.4.03h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7-.25c.41 0 .75.34.75.75s-.34.75-.75.75-.75-.34-.75-.75.34-.75.75-.75zM19 19H5V5h14v14z"
+				}}</v-icon>
+			</h2>
 			<h2>{{ reactiveValue }}</h2>
 			<br />
 			<div>
@@ -40,6 +45,7 @@
 </template>
 
 <script lang="ts">
+import { mdiHome } from "@mdi/js";
 import { defineComponent, ref } from "vue";
 import { useCounterStore } from "@/store/counter";
 import { computed } from "vue";
@@ -76,6 +82,7 @@ export default defineComponent({
 			onIncreaseStoreCounter,
 			dialogIsOpen,
 			onCloseDialog,
+			mdiHome,
 		};
 	},
 });

--- a/vue3_poc/src/pages/HomePage.vue
+++ b/vue3_poc/src/pages/HomePage.vue
@@ -2,10 +2,9 @@
 	<div>
 		<div>
 			<h2 class="text-h2">
-				{{ persistentValue }} <v-icon>{{ mdiHome }}</v-icon
-				><v-icon>{{
-					"M7 15h7v2H7zm0-4h10v2H7zm0-4h10v2H7zm12-4h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-.14 0-.27.01-.4.04a2.008 2.008 0 0 0-1.44 1.19c-.1.23-.16.49-.16.77v14c0 .27.06.54.16.78s.25.45.43.64c.27.27.62.47 1.01.55.13.02.26.03.4.03h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7-.25c.41 0 .75.34.75.75s-.34.75-.75.75-.75-.34-.75-.75.34-.75.75-.75zM19 19H5V5h14v14z"
-				}}</v-icon>
+				{{ persistentValue }}
+				<v-icon :icon="mdiHome"></v-icon>
+				<v-icon :icon="bcAssignment"></v-icon>
 			</h2>
 			<h2>{{ reactiveValue }}</h2>
 			<br />
@@ -50,6 +49,7 @@ import { defineComponent, ref } from "vue";
 import { useCounterStore } from "@/store/counter";
 import { computed } from "vue";
 import vCustomDialog from "@/components/vCustomDialog.vue";
+import { bcAssignment } from "@/styles/icons";
 export default defineComponent({
 	components: {
 		vCustomDialog,
@@ -83,6 +83,7 @@ export default defineComponent({
 			dialogIsOpen,
 			onCloseDialog,
 			mdiHome,
+			bcAssignment,
 		};
 	},
 });

--- a/vue3_poc/src/plugins/vuetify.ts
+++ b/vue3_poc/src/plugins/vuetify.ts
@@ -1,7 +1,7 @@
 // Styles
-import "@mdi/font/css/materialdesignicons.css";
 import "../styles/roboto-font-face.css";
 import "../styles/vuetify.scss";
+import { aliases, mdi } from "vuetify/iconsets/mdi-svg";
 
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
@@ -17,6 +17,13 @@ export default createVuetify({
 		defaultTheme: "customTheme",
 		themes: {
 			customTheme,
+		},
+	},
+	icons: {
+		defaultSet: "mdi",
+		aliases,
+		sets: {
+			mdi,
 		},
 	},
 });

--- a/vue3_poc/src/styles/icons.ts
+++ b/vue3_poc/src/styles/icons.ts
@@ -1,0 +1,19 @@
+/**
+ * Place custom Icons in this file
+ *
+ * Custom Icons should be prefixed with **bc**
+ *
+ * Usage:
+ *
+ * Import Icon in your component.
+ *
+ * `import { bcIcon } from '@/styles/icons'`
+ *
+ * Use `v-icon` component to render the Icon.
+ *
+ * `<v-icon :icon="bcIcon"></v-icon>`
+ */
+
+/**/
+export const bcAssignment =
+	"M19 3h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-7 0c.55 0 1 .45 1 1s-.45 1-1 1-1-.45-1-1 .45-1 1-1zm2 14H7v-2h7v2zm3-4H7v-2h10v2zm0-4H7V7h10v2z";


### PR DESCRIPTION
# Short Description

Adds a pattern to add custom icons in addition to vuetify's default @mdi.js icons.

## Links to Ticket and related Pull-Requests

https://ticketsystem.dbildungscloud.de/browse/BC-2378

## Checklist before merging

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
