### PR TITLE
BC-2570 - add feature toggle for new share course flow

### DIFF
--- a/src/pages/room-details.unit.ts
+++ b/src/pages/room-details.unit.ts
@@ -396,7 +396,7 @@ describe("@pages/RoomDetails.page.vue", () => {
 
 		it("should call store action after 'Share Course' menu clicked", async () => {
 			// @ts-ignore
-			envConfigModule.setEnvs({ FEATURE_COURSE_SHARE: true });
+			envConfigModule.setEnvs({ FEATURE_COURSE_SHARE_NEW: true });
 			// const createCourseShareTokenSpy = jest.fn();
 			// shareCourseModule.createCourseShareToken = createCourseShareTokenSpy;
 			const wrapper = getWrapper();


### PR DESCRIPTION
# Short Description
The new shareCourse-function needs to be hidden to the users as the new shared course import is not implemented yet.
That's why we need to introduce an additional feature toggle to be able to enable and disable the new and the old ShareCourse-Feature separately.

This PR 
- reroutes the "old" feature toggle FEATURE_COURSE_SHARE to the old share-flow
- reintroduces the replaced parts of the old share-flow
- handles the "new" feature toggle FEATURE_COURSE_SHARE_NEW to the new share-flow

## Links to Ticket and related Pull-Requests
https://ticketsystem.dbildungscloud.de/browse/BC-2570

## Changes

<!--
- What will the PR change?
- Why are the changes required?
- Links to documentation / tickets if exists, or provide more details here.
-->

## Data-security

<!--
Please note here about:
- any data model changes
- any changes about logging of user data
- any changes about permissions
- user input, authentication and other user data related things
If you are not sure if it is relevant, take a look at confluence or ask the data-security team.
-->

## Deployment

<!--
Keep in mind to changes to seed data, if changes are done by migration scripts.
Changes to the infrastructure have to discussed with the devops.
This information should be also in corresponding ticket, and collected in release deployment ticket.

This point should includes following information:
- What else is required for its deployment?
- Environment variables like FEATURE_XY=true
- Are there any migration scripts to be run?
-->

## New Repos, NPM packages or vendor scripts

<!--
- Keep in mind the stability, performance, activity and author.
- Describe why it is needed.
-->

## Screenshots of UI changes

<!--
- For UI changes, insert screenshots here.
- Has it been reviewed by a UX colleague?
-->

## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
