### PR TITLE
BC-2364 Display toast when trying to send mail to an already registered user

### DIFF
--- a/locale/de.json
+++ b/locale/de.json
@@ -478,6 +478,7 @@
 	"pages.administration.selected": "ausgewählt",
 	"pages.administration.actions": "Aktionen",
 	"pages.administration.sendMail.success": "Registrierungslink(s) erfolgreich verschickt",
+	"pages.administration.sendMail.alreadyRegistered": "Die Registrierungsmail wurde nicht versendet, weil bereits eine Registrierung erfolgt ist",
 	"pages.administration.students.consent.cancel.modal.confirm": "Trotzdem abbrechen",
 	"pages.administration.students.consent.cancel.modal.continue": "Registrierung weiter machen",
 	"pages.administration.students.consent.cancel.modal.download.continue": "Zugangsdaten drucken",

--- a/locale/en.json
+++ b/locale/en.json
@@ -472,6 +472,7 @@
 	"pages.administration.actions": "Actions",
 	"pages.administration.sendMail.error": "Registration link could not be sent | Registration links could not be sent",
 	"pages.administration.sendMail.success": "Registration link sent successfully | Registration links sent successfully",
+	"pages.administration.sendMail.alreadyRegistered": "The registration email was not sent because a registration has already been made",
 	"pages.administration.students.consent.cancel.modal.confirm": "Cancel anyway",
 	"pages.administration.students.consent.cancel.modal.continue": "Continue registration",
 	"pages.administration.students.consent.cancel.modal.download.continue": "Zugangsdaten drucken",

--- a/locale/es.json
+++ b/locale/es.json
@@ -467,6 +467,7 @@
 	"pages.administration.remove.success": "Usuarios seleccionados eliminados",
 	"pages.administration.sendMail.error": "No se ha podido enviar el enlace de registro | No se han podido enviar los enlaces de registro",
 	"pages.administration.sendMail.success": "Enlace de registro enviado correctamente | Enlaces de registro enviados correctamente",
+	"pages.administration.sendMail.alreadyRegistered": "El correo electrónico de registro no se ha enviado porque el registro ya ha tenido lugar",
 	"pages.administration.or": "o",
 	"pages.administration.all": "todos",
 	"pages.administration.select": "seleccionad@s",

--- a/locale/ua.json
+++ b/locale/ua.json
@@ -546,6 +546,7 @@
 	"pages.administration.selected": "вибрано",
 	"pages.administration.sendMail.error": "Не вдалося надіслати посилання на реєстрацію | Не вдалося надіслати посилання на реєстрацію",
 	"pages.administration.sendMail.success": "Посилання на реєстрацію успішно надіслано | Посилання на реєстрацію успішно надіслано",
+	"pages.administration.sendMail.alreadyRegistered": "Реєстраційний лист не було надіслано, оскільки реєстрація вже відбулася",
 	"pages.administration.students.consent.cancel.modal.confirm": "Все одно скасувати",
 	"pages.administration.students.consent.cancel.modal.continue": "Продовжити реєстрацію",
 	"pages.administration.students.consent.cancel.modal.download.continue": "Роздрукувати дані доступу",

--- a/src/pages/administration/StudentOverview.page.vue
+++ b/src/pages/administration/StudentOverview.page.vue
@@ -252,6 +252,7 @@ export default {
 			isDeleting: "getActive",
 			deletedPercent: "getPercent",
 			qrLinks: "getQrLinks",
+			registrationLinks: "getRegistrationLinks",
 		}),
 		schoolIsExternallyManaged() {
 			return schoolsModule.schoolIsExternallyManaged;
@@ -502,9 +503,15 @@ export default {
 					userIds: rowIds,
 					selectionType,
 				});
-				this.$toast.success(
-					this.$tc("pages.administration.sendMail.success", rowIds.length)
-				);
+				if (this.registrationLinks.totalMailsSend === rowIds.length) {
+					this.$toast.success(
+						this.$tc("pages.administration.sendMail.success", rowIds.length)
+					);
+				} else {
+					this.$toast.info(
+						this.$tc("pages.administration.sendMail.alreadyRegistered")
+					);
+				}
 			} catch (error) {
 				console.error(error);
 				this.$toast.error(

--- a/src/store/users.js
+++ b/src/store/users.js
@@ -19,6 +19,7 @@ const module = mergeDeep(base, {
 			},
 			qrLinks: [],
 			consentList: [],
+			registrationLinks: [],
 		}),
 	mutations: {
 		startProgress(state, { action }) {
@@ -38,6 +39,9 @@ const module = mergeDeep(base, {
 		setConsentList(state, { data }) {
 			state.consentList = data;
 		},
+		setRegistrationLinks(state, payload) {
+			state.registrationLinks = payload;
+		},
 	},
 	getters: {
 		getPagination(state) {
@@ -54,6 +58,9 @@ const module = mergeDeep(base, {
 		},
 		getConsentList(state) {
 			return state.consentList;
+		},
+		getRegistrationLinks(state) {
+			return state.registrationLinks;
 		},
 	},
 	actions: {
@@ -144,9 +151,10 @@ const module = mergeDeep(base, {
 				commit("setBusinessError", error.response.data);
 			}
 		},
-		async sendRegistrationLink(ctx, payload = {}) {
+		async sendRegistrationLink({ commit }, payload = {}) {
 			const registrationLinkEndpoint = "/v1/users/mail/registrationLink";
-			await this.$axios.$post(registrationLinkEndpoint, payload);
+			const links = await this.$axios.$post(registrationLinkEndpoint, payload);
+			commit("setRegistrationLinks", links);
 		},
 		async getQrRegistrationLinks({ commit }, payload = {}) {
 			const registrationQrEndpoint = "/v1/users/qrRegistrationLink";

--- a/src/store/users.unit.js
+++ b/src/store/users.unit.js
@@ -79,7 +79,9 @@ describe("store/users", () => {
 		describe("sendRegistrationLink", () => {
 			it("should call backend", async () => {
 				const receivedRequests = [];
-				const ctxMock = {};
+				const ctxMock = {
+					commit: () => {},
+				};
 				const payloadMock = {
 					someProperty: "some value",
 				};


### PR DESCRIPTION
# Short Description 
When an administrator/teacher tries to send an email to an already registered user, the corresponding toast is displayed

## Links to Ticket and related Pull-Requests
- https://ticketsystem.dbildungscloud.de/browse/BC-2364
- https://github.com/hpi-schul-cloud/nuxt-client/pull/2313

## Changes
- toast with a message about an already registered user
- translations for toast

## Data-security

## Deployment

## New Repos, NPM packages or vendor scripts

## Screenshots of UI changes
<img width="1677" alt="Fixed" src="https://user-images.githubusercontent.com/116640614/201943583-3e4f7fe0-bc1c-4673-98d2-0e913b93ad33.png">

## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
