### PR TITLE
Devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,13 @@
 {
 	"name": "frontend",
 	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-18",
-
+	
+	"containerEnv": {
+		"PUBLIC_BACKEND_URL": "http://host.docker.internal:3030/api",
+		"API_HOST": "http://host.docker.internal:3030/api",
+		"SERVER_HOST": "http://host.docker.internal:3030/",
+		"LEGACY_CLIENT_URL": "http://host.docker.internal:3030/api"
+	},
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},
 
@@ -14,5 +20,8 @@
 	  "source=${localWorkspaceFolderBasename}-dist,target=${containerWorkspaceFolder}/dist,type=volume"
 	],
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	"remoteUser": "root"
+	"remoteUser": "root",
+	"features": {
+		"ghcr.io/stuartleeks/dev-container-features/shell-history:0": {}
+	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,6 @@
 	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-18",
 	
 	"containerEnv": {
-		"PUBLIC_BACKEND_URL": "http://host.docker.internal:3030/api",
 		"API_HOST": "http://host.docker.internal:3030/api",
 		"SERVER_HOST": "http://host.docker.internal:3030",
 		"LEGACY_CLIENT_URL": "http://host.docker.internal:3100"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,8 @@
 	 "forwardPorts": [4000],
 	 
 	"mounts": [
-	  "source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
+	  "source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume",
+	  "source=${localWorkspaceFolderBasename}-dist,target=${containerWorkspaceFolder}/dist,type=volume"
 	],
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	"remoteUser": "root"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+	"name": "frontend",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:0-18",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	 "forwardPorts": [4000],
+	 
+	"mounts": [
+	  "source=${localWorkspaceFolderBasename}-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
+	],
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	"remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,8 +6,8 @@
 	"containerEnv": {
 		"PUBLIC_BACKEND_URL": "http://host.docker.internal:3030/api",
 		"API_HOST": "http://host.docker.internal:3030/api",
-		"SERVER_HOST": "http://host.docker.internal:3030/",
-		"LEGACY_CLIENT_URL": "http://host.docker.internal:3030/api"
+		"SERVER_HOST": "http://host.docker.internal:3030",
+		"LEGACY_CLIENT_URL": "http://host.docker.internal:3100"
 	},
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	// "features": {},

--- a/webpack-config/dev-server-config.js
+++ b/webpack-config/dev-server-config.js
@@ -5,7 +5,9 @@ const url = require("url");
 
 const createLegacyClientProxy = () => {
 	const legacyClientProxy = createProxyMiddleware({
-		target: "http://localhost:3100",
+		target: process.env.LEGACY_CLIENT_URL
+			? process.env.LEGACY_CLIENT_URL
+			: "http://localhost:3100",
 		changeOrigin: true,
 	});
 	return legacyClientProxy;
@@ -13,7 +15,9 @@ const createLegacyClientProxy = () => {
 
 const createServerProxy = () => {
 	const serverProxy = createProxyMiddleware({
-		target: "http://localhost:3030",
+		target: process.env.SERVER_HOST
+			? process.env.SERVER_HOST
+			: "http://localhost:3030",
 		changeOrigin: true,
 	});
 	return serverProxy;


### PR DESCRIPTION
# Short Description

This adds support for devcontainers (see also https://github.com/hpi-schul-cloud/schulcloud-server/pull/4020).

Running devcontainer for the SPA frontend will also require running  server and legacy client in docker (see how we set the URLs to the docker host).

