### PR TITLE
BC-4939 - fix update height

### DIFF
--- a/src/components/feature-board/card/CardHost.vue
+++ b/src/components/feature-board/card/CardHost.vue
@@ -96,12 +96,7 @@ import {
 	BoardMenuActionDelete,
 	BoardMenuActionEdit,
 } from "@ui-board";
-import {
-	useDebounceFn,
-	useElementHover,
-	useElementSize,
-	watchDebounced,
-} from "@vueuse/core";
+import { useDebounceFn, useElementHover, useElementSize } from "@vueuse/core";
 import { computed, defineComponent, ref, toRef } from "vue";
 import { useAddElementDialog } from "../shared/AddElementDialog.composable";
 import CardAddElementMenu from "./CardAddElementMenu.vue";
@@ -111,6 +106,7 @@ import CardTitle from "./CardTitle.vue";
 import ContentElementList from "./ContentElementList.vue";
 import CardHostDetailView from "./CardHostDetailView.vue";
 import { mdiArrowExpand } from "@mdi/js";
+import { delay } from "@/utils/helpers";
 
 export default defineComponent({
 	name: "CardHost",
@@ -172,7 +168,11 @@ export default defineComponent({
 
 		const onStartEditMode = () => startEditMode();
 
-		const onEndEditMode = () => stopEditMode();
+		const onEndEditMode = async () => {
+			stopEditMode();
+			await delay(300);
+			updateCardHeight(cardHostHeight.value);
+		};
 
 		const onOpenDetailView = () => (isDetailView.value = true);
 		const onCloseDetailView = () => (isDetailView.value = false);
@@ -203,15 +203,6 @@ export default defineComponent({
 			}
 			return "hidden";
 		});
-
-		watchDebounced(
-			cardHostHeight,
-			(newHeight: number) => updateCardHeight(newHeight),
-			{
-				debounce: 500,
-				maxWait: 2000,
-			}
-		);
 
 		return {
 			boardMenuClasses,


### PR DESCRIPTION
# Short Description
**Situation**:
The board sends several updateHeight-requests to the backend - whenever the height of card changes. 
Some of these changes are only temporary and should not trigger the update.
Some of those are evening triggered when e.g. a student surfes on the board.

**Fix**:
Only after finishing the editing of a card the current rendered height of the card is send via an updateHeight-request to the backend.

## Links to Ticket and related Pull-Requests
https://ticketsystem.dbildungscloud.de/browse/BC-4939

## Changes
Internals of the CardHost-component

## Data-security
--

## Deployment
--

## New Repos, NPM packages or vendor scripts
--

## Screenshots of UI changes
--

## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
