### PR TITLE
BC-6175 - Vue3 upgrade: fix components/feature-board-text-element & /feature-editor tests

### DIFF
--- a/src/components/feature-board-text-element/RichTextContentElement.unit.ts
+++ b/src/components/feature-board-text-element/RichTextContentElement.unit.ts
@@ -1,13 +1,12 @@
 import { ContentElementType, RichTextElementResponse } from "@/serverApi/v3";
 import NotifierModule from "@/store/notifier";
-import { I18N_KEY, NOTIFIER_MODULE_KEY } from "@/utils/inject";
+import { NOTIFIER_MODULE_KEY } from "@/utils/inject";
 import { createModuleMocks } from "@/utils/mock-store-module";
-import createComponentMocks from "@@/tests/test-utils/componentMocks";
-import { MountOptions, shallowMount, Wrapper } from "@vue/test-utils";
-import Vue from "vue";
+import { mount } from "@vue/test-utils";
 import RichTextContentElementComponent from "./RichTextContentElement.vue";
 import RichTextContentElementDisplayComponent from "./RichTextContentElementDisplay.vue";
 import RichTextContentElementEditComponent from "./RichTextContentElementEdit.vue";
+import { createTestingI18n, createTestingVuetify } from "@@/tests/test-utils/setup";
 jest.mock("@data-board", () => {
 	return {
 		useBoardFocusHandler: jest.fn(),
@@ -41,31 +40,30 @@ const TEST_ELEMENT: RichTextElementResponse = {
 };
 
 describe("RichTextContentElement", () => {
-	let wrapper: Wrapper<Vue>;
 	const notifierModule = createModuleMocks(NotifierModule);
 
 	const setup = (props: {
 		element: RichTextElementResponse;
 		isEditMode: boolean;
 	}) => {
-		document.body.setAttribute("data-app", "true");
-
-		wrapper = shallowMount(
-			RichTextContentElementComponent as MountOptions<Vue>,
+		const wrapper = mount(
+			RichTextContentElementComponent,
 			{
-				...createComponentMocks({}),
 				propsData: props,
-				provide: {
-					[I18N_KEY.valueOf()]: { t: (key: string) => key },
-					[NOTIFIER_MODULE_KEY.valueOf()]: notifierModule,
+				global: {
+					plugins: [createTestingVuetify(), createTestingI18n()],
+					provide: { [NOTIFIER_MODULE_KEY.valueOf()]: notifierModule},
+
 				},
 			}
 		);
+
+		return wrapper;
 	};
 
 	describe("when component is mounted", () => {
 		it("should render display if isEditMode is false", () => {
-			setup({
+			const wrapper = setup({
 				element: TEST_ELEMENT,
 				isEditMode: false,
 			});
@@ -75,7 +73,7 @@ describe("RichTextContentElement", () => {
 		});
 
 		it("should render edit if isEditMode is true", () => {
-			setup({
+			const wrapper = setup({
 				element: TEST_ELEMENT,
 				isEditMode: true,
 			});
@@ -85,7 +83,7 @@ describe("RichTextContentElement", () => {
 		});
 
 		it("should call deleteElement when it receives delete:element event from edit component", async () => {
-			setup({
+			const wrapper = setup({
 				element: TEST_ELEMENT,
 				isEditMode: true,
 			});
@@ -95,10 +93,12 @@ describe("RichTextContentElement", () => {
 			);
 			richTextContentElementEditComponent.vm.$emit("delete:element");
 			await wrapper.vm.$nextTick();
-			const emitted = wrapper.emitted()["delete:element"] ?? [];
+			const emitted = wrapper.emitted("delete:element");
 
-			expect(emitted).toHaveLength(1);
-			expect(emitted[0][0]).toStrictEqual("test-id");
+			if(emitted) {
+				expect(emitted).toHaveLength(1);
+				expect(emitted[0][0]).toStrictEqual("test-id");
+			}
 		});
 	});
 });

--- a/src/components/feature-board-text-element/RichTextContentElement.unit.ts
+++ b/src/components/feature-board-text-element/RichTextContentElement.unit.ts
@@ -6,7 +6,10 @@ import { mount } from "@vue/test-utils";
 import RichTextContentElementComponent from "./RichTextContentElement.vue";
 import RichTextContentElementDisplayComponent from "./RichTextContentElementDisplay.vue";
 import RichTextContentElementEditComponent from "./RichTextContentElementEdit.vue";
-import { createTestingI18n, createTestingVuetify } from "@@/tests/test-utils/setup";
+import {
+	createTestingI18n,
+	createTestingVuetify,
+} from "@@/tests/test-utils/setup";
 jest.mock("@data-board", () => {
 	return {
 		useBoardFocusHandler: jest.fn(),
@@ -46,24 +49,20 @@ describe("RichTextContentElement", () => {
 		element: RichTextElementResponse;
 		isEditMode: boolean;
 	}) => {
-		const wrapper = mount(
-			RichTextContentElementComponent,
-			{
-				propsData: props,
-				global: {
-					plugins: [createTestingVuetify(), createTestingI18n()],
-					provide: { [NOTIFIER_MODULE_KEY.valueOf()]: notifierModule},
+		const wrapper = mount(RichTextContentElementComponent, {
+			propsData: props,
+			global: {
+				plugins: [createTestingVuetify(), createTestingI18n()],
+				provide: { [NOTIFIER_MODULE_KEY.valueOf()]: notifierModule },
+			},
+		});
 
-				},
-			}
-		);
-
-		return wrapper;
+		return { wrapper };
 	};
 
 	describe("when component is mounted", () => {
 		it("should render display if isEditMode is false", () => {
-			const wrapper = setup({
+			const { wrapper } = setup({
 				element: TEST_ELEMENT,
 				isEditMode: false,
 			});
@@ -73,7 +72,7 @@ describe("RichTextContentElement", () => {
 		});
 
 		it("should render edit if isEditMode is true", () => {
-			const wrapper = setup({
+			const { wrapper } = setup({
 				element: TEST_ELEMENT,
 				isEditMode: true,
 			});
@@ -83,7 +82,7 @@ describe("RichTextContentElement", () => {
 		});
 
 		it("should call deleteElement when it receives delete:element event from edit component", async () => {
-			const wrapper = setup({
+			const { wrapper } = setup({
 				element: TEST_ELEMENT,
 				isEditMode: true,
 			});
@@ -95,7 +94,7 @@ describe("RichTextContentElement", () => {
 			await wrapper.vm.$nextTick();
 			const emitted = wrapper.emitted("delete:element");
 
-			if(emitted) {
+			if (emitted) {
 				expect(emitted).toHaveLength(1);
 				expect(emitted[0][0]).toStrictEqual("test-id");
 			}

--- a/src/components/feature-board-text-element/RichTextContentElementDisplay.unit.ts
+++ b/src/components/feature-board-text-element/RichTextContentElementDisplay.unit.ts
@@ -1,30 +1,29 @@
-import createComponentMocks from "@@/tests/test-utils/componentMocks";
-import { MountOptions, mount, Wrapper } from "@vue/test-utils";
-import Vue from "vue";
+import { shallowMount } from "@vue/test-utils";
 import RichTextContentElementDisplay from "./RichTextContentElementDisplay.vue";
+import { RenderHTML } from "@feature-render-html";
 
 describe("RichTextContentElementDisplay", () => {
-	let wrapper: Wrapper<Vue>;
-
-	const setup = (props: { value?: string }) => {
-		document.body.setAttribute("data-app", "true");
-		wrapper = mount(RichTextContentElementDisplay as MountOptions<Vue>, {
-			...createComponentMocks({}),
-			propsData: props,
+	const setup = (options: {}) => {
+		const wrapper = shallowMount(RichTextContentElementDisplay, {
+			props: {
+				...options
+			},
 		});
+
+		return wrapper;
 	};
 
 	describe("when component is mounted", () => {
 		it("should be found in dom", () => {
-			setup({ value: "test value" });
-			expect(
-				wrapper.findComponent(RichTextContentElementDisplay).exists()
-			).toBe(true);
+			const wrapper = setup({ value: "test value" });
+			const content = wrapper.findComponent(RichTextContentElementDisplay);
+			expect(content.exists()).toBe(true);
 		});
 
 		it("should pass props to ck-editor component", () => {
-			setup({ value: "test value" });
-			expect(wrapper.text()).toStrictEqual("test value");
+			const wrapper = setup({ value: "test value" });
+			const editorComponent = wrapper.findComponent(RenderHTML);
+			expect(editorComponent.vm.html).toStrictEqual("test value");
 		});
 	});
 });

--- a/src/components/feature-board-text-element/RichTextContentElementDisplay.unit.ts
+++ b/src/components/feature-board-text-element/RichTextContentElementDisplay.unit.ts
@@ -1,13 +1,17 @@
-import { shallowMount } from "@vue/test-utils";
+import { mount } from "@vue/test-utils";
 import RichTextContentElementDisplay from "./RichTextContentElementDisplay.vue";
 import { RenderHTML } from "@feature-render-html";
+import vueDompurifyHTMLPlugin from "vue-dompurify-html";
 
 describe("RichTextContentElementDisplay", () => {
 	const setup = (options: {}) => {
-		const wrapper = shallowMount(RichTextContentElementDisplay, {
+		const wrapper = mount(RichTextContentElementDisplay, {
 			props: {
 				...options
 			},
+			global: {
+				plugins: [vueDompurifyHTMLPlugin],
+			}
 		});
 
 		return wrapper;
@@ -23,7 +27,7 @@ describe("RichTextContentElementDisplay", () => {
 		it("should pass props to ck-editor component", () => {
 			const wrapper = setup({ value: "test value" });
 			const editorComponent = wrapper.findComponent(RenderHTML);
-			expect(editorComponent.vm.html).toStrictEqual("test value");
+			expect(editorComponent.text()).toStrictEqual("test value");
 		});
 	});
 });

--- a/src/components/feature-board-text-element/RichTextContentElementDisplay.unit.ts
+++ b/src/components/feature-board-text-element/RichTextContentElementDisplay.unit.ts
@@ -7,25 +7,25 @@ describe("RichTextContentElementDisplay", () => {
 	const setup = (options: {}) => {
 		const wrapper = mount(RichTextContentElementDisplay, {
 			props: {
-				...options
+				...options,
 			},
 			global: {
 				plugins: [vueDompurifyHTMLPlugin],
-			}
+			},
 		});
 
-		return wrapper;
+		return { wrapper };
 	};
 
 	describe("when component is mounted", () => {
 		it("should be found in dom", () => {
-			const wrapper = setup({ value: "test value" });
+			const { wrapper } = setup({ value: "test value" });
 			const content = wrapper.findComponent(RichTextContentElementDisplay);
 			expect(content.exists()).toBe(true);
 		});
 
 		it("should pass props to ck-editor component", () => {
-			const wrapper = setup({ value: "test value" });
+			const { wrapper } = setup({ value: "test value" });
 			const editorComponent = wrapper.findComponent(RenderHTML);
 			expect(editorComponent.text()).toStrictEqual("test value");
 		});

--- a/src/components/feature-board-text-element/RichTextContentElementEdit.unit.ts
+++ b/src/components/feature-board-text-element/RichTextContentElementEdit.unit.ts
@@ -1,6 +1,9 @@
 import { mount } from "@vue/test-utils";
 import RichTextContentElementEdit from "./RichTextContentElementEdit.vue";
-import { createTestingI18n, createTestingVuetify } from "@@/tests/test-utils/setup";
+import {
+	createTestingI18n,
+	createTestingVuetify,
+} from "@@/tests/test-utils/setup";
 
 describe("RichTextContentElementEdit", () => {
 	const setup = (options: {}) => {
@@ -9,29 +12,31 @@ describe("RichTextContentElementEdit", () => {
 				plugins: [createTestingVuetify(), createTestingI18n()],
 			},
 			props: {
-				...options
-			}
+				...options,
+			},
 		});
 
-		return wrapper;
+		return { wrapper };
 	};
 
 	describe("when component is mounted", () => {
 		it("should be found in dom", () => {
-			const wrapper = setup({ value: "test value", autofocus: false });
+			const { wrapper } = setup({ value: "test value", autofocus: false });
 			const content = wrapper.findComponent(RichTextContentElementEdit);
 			expect(content.exists()).toBe(true);
 		});
 
 		it("should pass props to ck-editor component", async () => {
-			const wrapper = setup({ value: "test value", autofocus: true });
+			const { wrapper } = setup({ value: "test value", autofocus: true });
 			const ckEditorComponent = wrapper.findComponent({ name: "ck-editor" });
-			const ckEditorValue = ckEditorComponent.findComponent({ name: "ckeditor" }).vm.modelValue;
+			const ckEditorValue = ckEditorComponent.findComponent({
+				name: "ckeditor",
+			}).vm.modelValue;
 			expect(ckEditorValue).toStrictEqual("test value");
 		});
 
 		it("should emit delete:element on CK editor keyboard delete event", async () => {
-			const wrapper = setup({ value: "test value", autofocus: true });
+			const { wrapper } = setup({ value: "test value", autofocus: true });
 			const ckEditor = wrapper.findComponent({ name: "ck-editor" });
 			ckEditor.vm.$emit("keyboard:delete");
 

--- a/src/components/feature-board-text-element/RichTextContentElementEdit.unit.ts
+++ b/src/components/feature-board-text-element/RichTextContentElementEdit.unit.ts
@@ -1,38 +1,37 @@
-import createComponentMocks from "@@/tests/test-utils/componentMocks";
-import { MountOptions, shallowMount, Wrapper } from "@vue/test-utils";
-import Vue from "vue";
+import { mount } from "@vue/test-utils";
 import RichTextContentElementEdit from "./RichTextContentElementEdit.vue";
+import { createTestingI18n, createTestingVuetify } from "@@/tests/test-utils/setup";
 
 describe("RichTextContentElementEdit", () => {
-	let wrapper: Wrapper<Vue>;
-
-	const setup = (props: { value: string; autofocus: boolean }) => {
-		document.body.setAttribute("data-app", "true");
-		wrapper = shallowMount(RichTextContentElementEdit as MountOptions<Vue>, {
-			...createComponentMocks({}),
-			propsData: props,
+	const setup = (options: {}) => {
+		const wrapper = mount(RichTextContentElementEdit, {
+			global: {
+				plugins: [createTestingVuetify(), createTestingI18n()],
+			},
+			props: {
+				...options
+			}
 		});
+
+		return wrapper;
 	};
 
 	describe("when component is mounted", () => {
 		it("should be found in dom", () => {
-			setup({ value: "test value", autofocus: false });
-			expect(wrapper.findComponent(RichTextContentElementEdit).exists()).toBe(
-				true
-			);
+			const wrapper = setup({ value: "test value", autofocus: false });
+			const content = wrapper.findComponent(RichTextContentElementEdit);
+			expect(content.exists()).toBe(true);
 		});
 
 		it("should pass props to ck-editor component", async () => {
-			setup({ value: "test value", autofocus: true });
-
-			const ckEditor = wrapper.findComponent({ name: "ck-editor" });
-
-			expect(ckEditor.props("value")).toStrictEqual("test value");
+			const wrapper = setup({ value: "test value", autofocus: true });
+			const ckEditorComponent = wrapper.findComponent({ name: "ck-editor" });
+			const ckEditorValue = ckEditorComponent.findComponent({ name: "ckeditor" }).vm.modelValue;
+			expect(ckEditorValue).toStrictEqual("test value");
 		});
 
 		it("should emit delete:element on CK editor keyboard delete event", async () => {
-			setup({ value: "test value", autofocus: true });
-
+			const wrapper = setup({ value: "test value", autofocus: true });
 			const ckEditor = wrapper.findComponent({ name: "ck-editor" });
 			ckEditor.vm.$emit("keyboard:delete");
 

--- a/src/components/feature-editor/CKEditor.unit.ts
+++ b/src/components/feature-editor/CKEditor.unit.ts
@@ -1,9 +1,5 @@
-import Vue from "vue";
-import { MountOptions, mount } from "@vue/test-utils";
-import createComponentMocks from "@@/tests/test-utils/componentMocks";
+import { shallowMount } from "@vue/test-utils";
 import CkEditor from "./CKEditor.vue";
-import { I18N_KEY } from "@/utils/inject";
-import { i18nMock } from "@@/tests/test-utils";
 import {
 	boardToolbarSimple,
 	boardToolbarRegular,
@@ -11,6 +7,10 @@ import {
 	boardPlugins,
 	newsPlugins,
 } from "./config";
+import {
+	createTestingI18n,
+	createTestingVuetify,
+} from "@@/tests/test-utils/setup";
 
 type CkEditorProps = {
 	value?: string;
@@ -33,30 +33,25 @@ class ResizeObserver {
 }
 
 describe("CKEditor", () => {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	let wrapper: any;
-
 	const setup = (props: CkEditorProps = {}) => {
-		document.body.setAttribute("data-app", "true");
-		wrapper = mount(CkEditor as MountOptions<Vue>, {
-			...createComponentMocks({
-				i18n: true,
-			}),
-			propsData: props,
-			provide: {
-				[I18N_KEY.valueOf()]: i18nMock,
+		const wrapper = shallowMount(CkEditor, {
+			global: {
+				plugins: [createTestingVuetify(), createTestingI18n()],
 			},
+			props,
 		});
+
+		const editorMock = { editing: { view: { document: { on: jest.fn() } } } };
+
+		return { wrapper, editorMock };
 	};
 
 	beforeEach(() => {
-		// Avoids console warnings "[Vuetify] Unable to locate target [data-app]"
-		document.body.setAttribute("data-app", "true");
 		window.ResizeObserver = ResizeObserver;
 	});
 
 	it("should render component", () => {
-		setup();
+		const { wrapper } = setup();
 		expect(wrapper.findComponent(CkEditor).exists()).toBe(true);
 	});
 
@@ -69,60 +64,62 @@ describe("CKEditor", () => {
 	});
 
 	it("should have reduced board toolbar items in simple mode", () => {
-		setup({ mode: "simple" });
+		const { wrapper } = setup({ mode: "simple" });
 		expect(wrapper.vm.config.toolbar.items).toHaveLength(
 			boardToolbarSimple.length
 		);
 	});
 
 	it("should have all board plugins available in simple mode", () => {
-		setup({ mode: "simple" });
+		const { wrapper } = setup({ mode: "simple" });
 		expect(wrapper.vm.config.plugins).toHaveLength(boardPlugins.length);
 	});
 
 	it("should have all boards toolbar items in regular mode", () => {
-		setup({ mode: "regular" });
+		const { wrapper } = setup({ mode: "regular" });
 		expect(wrapper.vm.config.toolbar.items).toHaveLength(
 			boardToolbarRegular.length
 		);
 	});
 
 	it("should have all board plugins available in regular mode", () => {
-		setup({ mode: "regular" });
+		const { wrapper } = setup({ mode: "regular" });
 		expect(wrapper.vm.config.plugins).toHaveLength(boardPlugins.length);
 	});
 
 	it("should have all news toolbar items in news mode", () => {
-		setup({ mode: "news" });
+		const { wrapper } = setup({ mode: "news" });
 		expect(wrapper.vm.config.toolbar.items).toHaveLength(newsToolbar.length);
 	});
 
 	it("should have all news plugins available in news mode", () => {
-		setup({ mode: "news" });
+		const { wrapper } = setup({ mode: "news" });
 		expect(wrapper.vm.config.plugins).toHaveLength(newsPlugins.length);
 	});
 
 	describe("events", () => {
 		it("should emit ready on editor ready", async () => {
-			setup();
+			const { wrapper, editorMock } = setup();
 
 			const ck = wrapper.findComponent({
 				ref: "ck",
 			});
-			ck.vm.$emit("ready", {});
+
+			ck.vm.$emit("ready", editorMock);
 			await wrapper.vm.$nextTick();
 
 			const emitted = wrapper.emitted();
+			expect(editorMock.editing.view.document.on).toHaveBeenCalled();
 			expect(emitted["ready"]).toHaveLength(1);
 		});
 
 		it("should emit update:value on content changes", async () => {
-			setup();
+			const { wrapper, editorMock } = setup();
 
 			const ck = wrapper.findComponent({
 				ref: "ck",
 			});
-			ck.vm.$emit("input");
+			ck.vm.$emit("update:modelValue", editorMock);
 			await wrapper.vm.$nextTick();
 
 			const emitted = wrapper.emitted();
@@ -130,12 +127,12 @@ describe("CKEditor", () => {
 		});
 
 		it("should emit focus on editor focus", async () => {
-			setup();
+			const { wrapper } = setup();
 
 			const ck = wrapper.findComponent({
 				ref: "ck",
 			});
-			ck.vm.$emit("focus");
+			ck.trigger("focus");
 			await wrapper.vm.$nextTick();
 
 			const emitted = wrapper.emitted();
@@ -144,7 +141,7 @@ describe("CKEditor", () => {
 
 		it("should emit delayed blur on editor blur", async () => {
 			jest.useFakeTimers();
-			setup();
+			const { wrapper } = setup();
 
 			const ck = wrapper.findComponent({
 				ref: "ck",
@@ -157,7 +154,7 @@ describe("CKEditor", () => {
 		});
 
 		it("should emit delete on delete event and empty text", async () => {
-			setup();
+			const { wrapper } = setup();
 
 			// due to not accessing the editor instance in test setup, we test here with implementation details
 			expect(wrapper.vm.charCount).toEqual(0);
@@ -168,10 +165,9 @@ describe("CKEditor", () => {
 		});
 
 		it("should not emit delete on delete event and non-empty text", async () => {
-			setup();
+			const { wrapper } = setup();
 
-			await wrapper.setData({ charCount: 1 });
-			expect(wrapper.vm.charCount).toEqual(1);
+			wrapper.vm.charCount = 1;
 			wrapper.vm.handleDelete();
 			await wrapper.vm.$nextTick();
 			const emitted = wrapper.emitted();

--- a/src/components/feature-editor/CKEditor.vue
+++ b/src/components/feature-editor/CKEditor.vue
@@ -46,7 +46,7 @@ export default defineComponent({
 			default: "",
 		},
 		placeholder: {
-			type: String,
+			type: [String, undefined],
 			default: "",
 		},
 		type: {


### PR DESCRIPTION
# Short Description
Because of the vue3 upgrade we need to refactor the following tests (src/components/):

    feature-board-text-element/RichTextContentElementDisplay.unit.ts
    feature-board-text-element/RichTextContentElementEdit.unit.ts
    feature-board-text-element/RichTextContentElement.unit.ts

    feature-editor/CKEditor.unit.ts
<!-- Write a short explanation of what this Pull Request does -->

<!--
  This Pull-Request template helps the reviewers as well as servers as a checklist for you. Please feel out all possible sections.

  Quality guidelines:
    - Code should be self-explanatory; Document code that is not self-explanatory
    - Code respects SOLID principles, DRY, YAGNI, KISS
    - Think about potential bugs this Pull Request might introduce
    - Keep security in mind
    - Write tests (Unit and Integration), including for error cases. Don't decrease coverage
    - Business logic should be implemented in the API; never trust the client
    - UI changes should be discussed & agreed with the UX-Team before staring
    - Boyscout rule: leave the code in a better state than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Ticket and related Pull-Requests
BC-6175
<!--
Base links to copy
- https://ticketsystem.dbildungscloud.de/browse/BC-????
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://github.com/hpi-schul-cloud/end-to-end-tests/pull/????
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
-->

## Checklist before merging

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
