### PR TITLE
BC-6165 - Vue3 upgrade: fix src/components/data-external-tool tests

### DIFF
--- a/src/components/data-external-tool/ContextExternalToolConfigurationStatus.composable.unit.ts
+++ b/src/components/data-external-tool/ContextExternalToolConfigurationStatus.composable.unit.ts
@@ -37,7 +37,6 @@ describe("ToolConfigurationStatus.composable", () => {
 				return {
 					toolConfigurationStatus,
 					...composable,
-					authModule,
 				};
 			};
 
@@ -79,7 +78,6 @@ describe("ToolConfigurationStatus.composable", () => {
 				return {
 					toolConfigurationStatus,
 					...composable,
-					authModule,
 				};
 			};
 
@@ -121,7 +119,6 @@ describe("ToolConfigurationStatus.composable", () => {
 				return {
 					toolConfigurationStatus,
 					...composable,
-					authModule,
 				};
 			};
 
@@ -265,13 +262,16 @@ describe("ToolConfigurationStatus.composable", () => {
 				const composable = mountComposable(
 					() => useContextExternalToolConfigurationStatus(),
 					{
-						[AUTH_MODULE_KEY.valueOf()]: authModule,
+						global: {
+							provide: {
+								[AUTH_MODULE_KEY.valueOf()]: authModule,
+							},
+						},
 					}
 				);
 
 				return {
 					...composable,
-					authModule,
 				};
 			};
 
@@ -295,7 +295,11 @@ describe("ToolConfigurationStatus.composable", () => {
 				const composable = mountComposable(
 					() => useContextExternalToolConfigurationStatus(),
 					{
-						[AUTH_MODULE_KEY.valueOf()]: authModule,
+						global: {
+							provide: {
+								[AUTH_MODULE_KEY.valueOf()]: authModule,
+							},
+						},
 					}
 				);
 

--- a/src/components/data-external-tool/ExternalToolLaunchState.composable.unit.ts
+++ b/src/components/data-external-tool/ExternalToolLaunchState.composable.unit.ts
@@ -25,8 +25,13 @@ describe("ExternalToolLaunchState.composable", () => {
 
 	afterEach(() => {
 		jest.clearAllMocks();
-
-		window.location.href = "";
+		Object.defineProperty(window, "location", {
+			configurable: true,
+			writable: false,
+			value: {
+				href: "",
+			},
+		});
 	});
 
 	describe("fetchLaunchRequest", () => {
@@ -233,6 +238,10 @@ describe("ExternalToolLaunchState.composable", () => {
 		});
 
 		describe("when the launch method is unknown", () => {
+			beforeEach(() => {
+				window.location.href = "";
+			});
+
 			const setup = () => {
 				const launchRequest = toolLaunchRequestFactory.build({
 					method: "unknown" as unknown as ToolLaunchRequestMethodEnum,

--- a/src/components/data-external-tool/ExternalToolLaunchState.composable.unit.ts
+++ b/src/components/data-external-tool/ExternalToolLaunchState.composable.unit.ts
@@ -13,6 +13,14 @@ import { useExternalToolLaunchState } from "./ExternalToolLaunchState.composable
 
 jest.mock("@data-external-tool/ExternalToolApi.composable");
 
+Object.defineProperty(window, "location", {
+	configurable: true,
+	writable: false,
+	value: {
+		href: "",
+	},
+});
+
 describe("ExternalToolLaunchState.composable", () => {
 	let useExternalToolApiMock: DeepMocked<ReturnType<typeof useExternalToolApi>>;
 
@@ -25,13 +33,7 @@ describe("ExternalToolLaunchState.composable", () => {
 
 	afterEach(() => {
 		jest.clearAllMocks();
-		Object.defineProperty(window, "location", {
-			configurable: true,
-			writable: false,
-			value: {
-				href: "",
-			},
-		});
+		window.location.href = "";
 	});
 
 	describe("fetchLaunchRequest", () => {
@@ -238,10 +240,6 @@ describe("ExternalToolLaunchState.composable", () => {
 		});
 
 		describe("when the launch method is unknown", () => {
-			beforeEach(() => {
-				window.location.href = "";
-			});
-
 			const setup = () => {
 				const launchRequest = toolLaunchRequestFactory.build({
 					method: "unknown" as unknown as ToolLaunchRequestMethodEnum,

--- a/src/components/data-external-tool/ExternalToolLaunchState.composable.unit.ts
+++ b/src/components/data-external-tool/ExternalToolLaunchState.composable.unit.ts
@@ -33,6 +33,7 @@ describe("ExternalToolLaunchState.composable", () => {
 
 	afterEach(() => {
 		jest.clearAllMocks();
+
 		window.location.href = "";
 	});
 


### PR DESCRIPTION
# Short Description

<!-- Write a short explanation of what this Pull Request does -->
Because of the vue3 upgrade we need to refactor the following tests (src/components/data-external-tool):

    data-external-tool/ContextExternalToolConfigurationStatus.composable.unit.ts
    data-external-tool/ContextExternalToolApi.composable.unit.ts
    data-external-tool/ExternalToolElementDisplayState.composable.unit.ts
    data-external-tool/ExternalToolLaunchState.composable.unit.ts
    data-external-tool/ExternalToolApi.composable.unit.ts
    data-external-tool/SchoolExternalToolApi.composable.unit.ts
    data-external-tool/SchoolExternalToolUsage.composable.unit.ts

<!--
  This Pull-Request template helps the reviewers as well as servers as a checklist for you. Please feel out all possible sections.

  Quality guidelines:
    - Code should be self-explanatory; Document code that is not self-explanatory
    - Code respects SOLID principles, DRY, YAGNI, KISS
    - Think about potential bugs this Pull Request might introduce
    - Keep security in mind
    - Write tests (Unit and Integration), including for error cases. Don't decrease coverage
    - Business logic should be implemented in the API; never trust the client
    - UI changes should be discussed & agreed with the UX-Team before staring
    - Boyscout rule: leave the code in a better state than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Ticket and related Pull-Requests
BC-6165
<!--
Base links to copy
- https://ticketsystem.dbildungscloud.de/browse/BC-????
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://github.com/hpi-schul-cloud/end-to-end-tests/pull/????
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
-->



## Checklist before merging

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
