### PR TITLE
BC-6391 - delete card error (Bughunt Vue3 | page 1 | bug #11)

### DIFF
--- a/src/components/data-board/BoardState.composable.ts
+++ b/src/components/data-board/BoardState.composable.ts
@@ -90,7 +90,6 @@ export const useBoardState = (id: string) => {
 		if (board.value === undefined) return;
 
 		try {
-			await deleteCardCall(id);
 			const columnIndex = board.value.columns.findIndex(
 				(column) => column.cards.find((c) => c.cardId === id) !== undefined
 			);
@@ -100,6 +99,7 @@ export const useBoardState = (id: string) => {
 				);
 				board.value.columns[columnIndex].cards.splice(cardIndex, 1);
 			}
+			await deleteCardCall(id);
 		} catch (error) {
 			handleError(error, {
 				404: notifyWithTemplateAndReload("notDeleted", "boardCard"),

--- a/src/components/feature-board/card/CardHost.vue
+++ b/src/components/feature-board/card/CardHost.vue
@@ -163,6 +163,7 @@ export default defineComponent({
 		const onUpdateCardTitle = useDebounceFn(updateTitle, 300);
 
 		const onDeleteCard = async (confirmation: Promise<boolean>) => {
+			stopEditMode();
 			const shouldDelete = await confirmation;
 			if (shouldDelete) {
 				emit("delete:card", card.value?.id);


### PR DESCRIPTION
# Short Description

### problems:
a. when triggering the deletion of a card (e.g. via menu), the card is not properly removed
b. sometimes during deletion an error alert message is shown in the right top corner that something went wrong

### solution for a: 
the board is updated first, then the backend-api-call is executed

when trying to reproduce the error and a card that was deleted contained big files, the api-request took longer  then the default timeout for each request ([see also: question from Sergej](https://teamchat.dbildungscloud.de/group/DevOps-SRE-Open?msg=iqGDJJoQKfXXFd4nv) )... which resulted in a silent stop of the execution of the delete action, resulting in an not removed card. Only reload of the page or triggering the deletion again led to an update of the board.

good: the server executes the deletion till the end - even if the timeout is reached
bad: normally that should not take that long
bad2: we would like to get somehow informed of things taking so long time... ideally in some server log or even - inform the user... if it is relevant for him/her

### solution for b:
when the card is in edit mode and the user opens the three-dot-menu and chooses the delete-action, two things happen in parallel: the delete action is started and the edit mode is ended. leaving the edit mode of a card automatically results in reporting the new height of card to the server (keyword: skeleton card, positioning), which can lead to an error message (if the card was already deleted). this is now prevent as the delete-card-action now directly finishes the editmode.

## Links to Ticket and related Pull-Requests
BC-6391


## Checklist before merging

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
