### PR TITLE
BC-6611 - wireframe layout scrollbar issue

### DIFF
--- a/src/components/page-board/ColumnBoard.page.vue
+++ b/src/components/page-board/ColumnBoard.page.vue
@@ -1,5 +1,10 @@
 <template>
-	<DefaultWireframe ref="main" :full-width="true" :breadcrumbs="breadcrumbs">
+	<DefaultWireframe
+		ref="main"
+		:full-width="true"
+		:breadcrumbs="breadcrumbs"
+		:allow-overflow-x="true"
+	>
 		<Board :board-id="boardId" />
 	</DefaultWireframe>
 </template>

--- a/src/components/templates/DefaultWireframe.vue
+++ b/src/components/templates/DefaultWireframe.vue
@@ -44,10 +44,11 @@
 		</div>
 		<v-container
 			:class="{
+				'main-content': true,
 				'container-max-width': !fullWidth,
 				'container-full-width': fullWidth,
+				'overflow-x': allowOverflowX,
 			}"
-			class="main-content"
 		>
 			<div style="padding: 0 var(--space-lg)">
 				<slot />
@@ -89,6 +90,11 @@ export default defineComponent({
 			required: false,
 			default: null,
 		},
+		allowOverflowX: {
+			type: Boolean,
+			required: false,
+			default: false,
+		},
 	},
 	computed: {
 		showBorder(): boolean {
@@ -122,8 +128,10 @@ export default defineComponent({
 }
 
 .main-content {
-	overflow-x: auto;
 	padding: 0;
+}
+.overflow-x {
+	overflow-x: auto;
 }
 
 .container-max-width {


### PR DESCRIPTION
# Short Description
The form to configure an external tool that should be added, was displayed with a scrollbar and the cancel and submit-button were not displayed completely (=cut off at the bottom).

## Links to Ticket and related Pull-Requests
BC-6611

## Changes
- added property **allowOverflowX** to the DefaultWirframe and activated it for the CoulmBoard-page:
  - **true**: menu-items of cards and columns outside of the screen (column 7+) are displayed with text
  - **false**: no problems with unwanted scrollbars
- property set to true for ColumnBoard-Page

## Screenshots of UI changes
see the ticket

## Checklist before merging
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
