### PR TITLE
EW-795 correcting data-testids for course import buttons

### DIFF
--- a/src/components/molecules/CommonCartridgeImportModal.vue
+++ b/src/components/molecules/CommonCartridgeImportModal.vue
@@ -27,15 +27,21 @@
 			<v-card-actions>
 				<v-spacer />
 				<div class="button-section">
-					<v-btn data-testid="dialog-cancel-btn" depressed @click="onCancel">
+					<v-btn
+						data-testid="dialog-cancel-btn"
+						variant="outlined"
+						@click="onCancel"
+					>
 						{{ $t("common.labels.close") }}
 					</v-btn>
 				</div>
 				<div class="button-section">
 					<v-btn
+						type="submit"
+						variant="flat"
+						color="primary"
 						v-bind:disabled="importButtonDisabled"
 						v-on:click="onConfirm"
-						color="primary"
 						data-testid="dialog-confirm-btn"
 					>
 						{{ $t("pages.rooms.ccImportCourse.confirm") }}
@@ -133,5 +139,6 @@ async function onConfirm(): Promise<void> {
 
 .button-section > button {
 	margin-left: calc(var(--space-base-vuetify) * 2);
+	margin-right: calc(var(--space-base-vuetify) * 2);
 }
 </style>

--- a/src/components/templates/RoomWrapper.vue
+++ b/src/components/templates/RoomWrapper.vue
@@ -74,19 +74,19 @@ export default defineComponent({
 						icon: mdiPlus,
 						title: this.$t("common.actions.create"),
 						ariaLabel: this.$t("pages.rooms.fab.ariaLabel"),
-						testId: "add-course-button",
+						dataTestId: "add-course-button",
 						actions: [
 							{
 								icon: mdiSchoolOutline,
 								label: this.$t("pages.rooms.fab.add.course"),
 								href: "/courses/add",
-								dataTestid: "fab_button_add_course",
+								dataTestId: "fab_button_add_course",
 								ariaLabel: this.$t("pages.rooms.fab.add.course"),
 							},
 							{
 								label: this.$t("pages.rooms.fab.import.course"),
 								icon: mdiImport,
-								dataTestid: "fab_button_import_course",
+								dataTestId: "fab_button_import_course",
 								ariaLabel: this.$t("pages.rooms.fab.import.course"),
 								customEvent: "import",
 							},


### PR DESCRIPTION
# Short Description
Fixing broken data-testids for the course import and align Common Cartridge import modal with SVS UI guidelines.

## Links to Ticket and related Pull-Requests
- <https://ticketsystem.dbildungscloud.de/browse/EW-795>

## Checklist before merging

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [ ] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
