### PR TITLE
BC-7298 - refactor failure actions

### DIFF
--- a/src/modules/data/board/boardActions/boardActionPayload.ts
+++ b/src/modules/data/board/boardActions/boardActionPayload.ts
@@ -1,9 +1,5 @@
 import { BoardResponse, CardResponse, ColumnResponse } from "@/serverApi/v3";
 import { ColumnMove } from "@/types/board/DragAndDrop";
-import {
-	BoardObjectType,
-	ErrorType,
-} from "@/components/error-handling/ErrorHandler.composable";
 
 export type CreateCardRequestPayload = {
 	columnId: string;
@@ -13,11 +9,7 @@ export type CreateCardSuccessPayload = {
 	columnId: string;
 	isOwnAction: boolean;
 };
-export type CreateCardFailurePayload = {
-	errorType: ErrorType;
-	boardObjectType: BoardObjectType;
-	requestPayload: CreateCardRequestPayload;
-};
+export type CreateCardFailurePayload = CreateCardRequestPayload;
 
 export type CreateColumnRequestPayload = {
 	boardId: string;
@@ -26,16 +18,13 @@ export type CreateColumnSuccessPayload = {
 	newColumn: ColumnResponse;
 	isOwnAction: boolean;
 };
-export type CreateColumnFailurePayload = {
-	errorType: ErrorType;
-	boardObjectType: BoardObjectType;
-	requestPayload: CreateColumnRequestPayload;
-};
+export type CreateColumnFailurePayload = CreateColumnRequestPayload;
 
 export type FetchBoardRequestPayload = {
 	boardId: string;
 };
 export type FetchBoardSuccessPayload = BoardResponse;
+export type FetchBoardFailurePayload = FetchBoardRequestPayload;
 
 export type DeleteColumnRequestPayload = {
 	columnId: string;
@@ -44,11 +33,7 @@ export type DeleteColumnSuccessPayload = {
 	columnId: string;
 	isOwnAction: boolean;
 };
-export type DeleteColumnFailurePayload = {
-	errorType: ErrorType;
-	boardObjectType: BoardObjectType;
-	requestPayload: DeleteColumnRequestPayload;
-};
+export type DeleteColumnFailurePayload = DeleteColumnRequestPayload;
 
 export type MoveCardRequestPayload = {
 	cardId: string;
@@ -71,11 +56,7 @@ export type MoveCardSuccessPayload = {
 	forceNextTick?: boolean;
 	isOwnAction: boolean;
 };
-export type MoveCardFailurePayload = {
-	errorType: ErrorType;
-	boardObjectType: BoardObjectType;
-	requestPayload: MoveCardRequestPayload;
-};
+export type MoveCardFailurePayload = MoveCardRequestPayload;
 
 export type MoveColumnRequestPayload = {
 	columnMove: ColumnMove;
@@ -87,11 +68,7 @@ export type MoveColumnSuccessPayload = {
 	byKeyboard: boolean;
 	isOwnAction: boolean;
 };
-export type MoveColumnFailurePayload = {
-	errorType: ErrorType;
-	boardObjectType: BoardObjectType;
-	requestPayload: MoveColumnRequestPayload;
-};
+export type MoveColumnFailurePayload = MoveColumnRequestPayload;
 
 export type UpdateColumnTitleRequestPayload = {
 	columnId: string;
@@ -102,11 +79,7 @@ export type UpdateColumnTitleSuccessPayload = {
 	newTitle: string;
 	isOwnAction: boolean;
 };
-export type UpdateColumnTitleFailurePayload = {
-	errorType: ErrorType;
-	boardObjectType: BoardObjectType;
-	requestPayload: UpdateColumnTitleRequestPayload;
-};
+export type UpdateColumnTitleFailurePayload = UpdateColumnTitleRequestPayload;
 
 export type DeleteBoardRequestPayload = {
 	id: string;
@@ -115,11 +88,7 @@ export type DeleteBoardSuccessPayload = {
 	id: string;
 	isOwnAction: boolean;
 };
-export type DeleteBoardFailurePayload = {
-	errorType: ErrorType;
-	boardObjectType: BoardObjectType;
-	requestPayload: DeleteBoardRequestPayload;
-};
+export type DeleteBoardFailurePayload = DeleteBoardRequestPayload;
 
 export type ReloadBoardPayload = {
 	id: string;
@@ -138,11 +107,7 @@ export type UpdateBoardTitleSuccessPayload = {
 	newTitle: string;
 	isOwnAction: boolean;
 };
-export type UpdateBoardTitleFailurePayload = {
-	errorType: ErrorType;
-	boardObjectType: BoardObjectType;
-	requestPayload: UpdateBoardTitleRequestPayload;
-};
+export type UpdateBoardTitleFailurePayload = UpdateBoardTitleRequestPayload;
 
 export type UpdateBoardVisibilityRequestPayload = {
 	boardId: string;
@@ -153,15 +118,7 @@ export type UpdateBoardVisibilitySuccessPayload = {
 	isVisible: boolean;
 	isOwnAction: boolean;
 };
-export type UpdateBoardVisibilityFailurePayload = {
-	errorType: ErrorType;
-	boardObjectType: BoardObjectType;
-	requestPayload: UpdateBoardVisibilityRequestPayload;
-};
+export type UpdateBoardVisibilityFailurePayload =
+	UpdateBoardVisibilityRequestPayload;
 
 export type DisconnectSocketRequestPayload = Record<string, never>;
-
-export type NotifyErrorPayload = {
-	errorType: ErrorType;
-	boardObjectType?: BoardObjectType;
-};

--- a/src/modules/data/board/boardActions/boardActions.ts
+++ b/src/modules/data/board/boardActions/boardActions.ts
@@ -11,6 +11,7 @@ import {
 	DeleteColumnRequestPayload,
 	DeleteColumnSuccessPayload,
 	DisconnectSocketRequestPayload,
+	FetchBoardFailurePayload,
 	FetchBoardRequestPayload,
 	FetchBoardSuccessPayload,
 	MoveCardFailurePayload,
@@ -19,7 +20,6 @@ import {
 	MoveColumnFailurePayload,
 	MoveColumnRequestPayload,
 	MoveColumnSuccessPayload,
-	NotifyErrorPayload,
 	ReloadBoardPayload,
 	ReloadBoardSuccessPayload,
 	UpdateBoardTitleFailurePayload,
@@ -121,10 +121,13 @@ export const fetchBoardRequest = createAction(
 	"fetch-board-request",
 	props<FetchBoardRequestPayload>()
 );
-
 export const fetchBoardSuccess = createAction(
 	"fetch-board-success",
 	props<FetchBoardSuccessPayload>()
+);
+export const fetchBoardFailure = createAction(
+	"fetch-board-failure",
+	props<FetchBoardFailurePayload>()
 );
 
 export const reloadBoard = createAction(
@@ -178,9 +181,4 @@ export const updateColumnTitleSuccess = createAction(
 export const updateColumnTitleFailure = createAction(
 	"update-column-title-failure",
 	props<UpdateColumnTitleFailurePayload>()
-);
-
-export const notifyError = createAction(
-	"notify-error",
-	props<NotifyErrorPayload>()
 );

--- a/src/modules/data/board/boardActions/boardSocketApi.composable.ts
+++ b/src/modules/data/board/boardActions/boardSocketApi.composable.ts
@@ -17,18 +17,6 @@ import {
 import { PermittedStoreActions, handle, on } from "@/types/board/ActionFactory";
 import { useErrorHandler } from "@/components/error-handling/ErrorHandler.composable";
 
-type ErrorActions =
-	| ReturnType<typeof BoardActions.createCardFailure>
-	| ReturnType<typeof BoardActions.createColumnFailure>
-	| ReturnType<typeof BoardActions.deleteBoardFailure>
-	| ReturnType<typeof CardActions.deleteCardFailure>
-	| ReturnType<typeof BoardActions.deleteColumnFailure>
-	| ReturnType<typeof BoardActions.moveCardFailure>
-	| ReturnType<typeof BoardActions.moveColumnFailure>
-	| ReturnType<typeof BoardActions.updateColumnTitleFailure>
-	| ReturnType<typeof BoardActions.updateBoardTitleFailure>
-	| ReturnType<typeof BoardActions.updateBoardVisibilityFailure>;
-
 export const useBoardSocketApi = () => {
 	const boardStore = useBoardStore();
 	const { notifySocketError } = useErrorHandler();
@@ -62,15 +50,19 @@ export const useBoardSocketApi = () => {
 			),
 
 			// failure actions
-			on(BoardActions.createCardFailure, onFailure),
-			on(BoardActions.createColumnFailure, onFailure),
-			on(CardActions.deleteCardFailure, onFailure),
-			on(BoardActions.deleteColumnFailure, onFailure),
-			on(BoardActions.moveCardFailure, onFailure),
-			on(BoardActions.moveColumnFailure, onFailure),
-			on(BoardActions.updateColumnTitleFailure, onFailure),
-			on(BoardActions.updateBoardTitleFailure, onFailure),
-			on(BoardActions.updateBoardVisibilityFailure, onFailure)
+			on(BoardActions.createCardFailure, createCardFailure),
+			on(BoardActions.createColumnFailure, createColumnFailure),
+			on(CardActions.deleteCardFailure, deleteCardFailure),
+			on(BoardActions.deleteColumnFailure, deleteColumnFailure),
+			on(BoardActions.fetchBoardFailure, fetchBoardFailure),
+			on(BoardActions.moveCardFailure, moveCardFailure),
+			on(BoardActions.moveColumnFailure, moveColumnFailure),
+			on(BoardActions.updateColumnTitleFailure, updateColumnTitleFailure),
+			on(BoardActions.updateBoardTitleFailure, updateBoardTitleFailure),
+			on(
+				BoardActions.updateBoardVisibilityFailure,
+				updateBoardVisibilityFailure
+			)
 		);
 	};
 
@@ -112,11 +104,7 @@ export const useBoardSocketApi = () => {
 			}
 			emitOnSocket("move-card-request", payload);
 		} catch (err) {
-			onFailure({
-				errorType: "notUpdated",
-				boardObjectType: "boardCard",
-				requestPayload: payload,
-			});
+			moveCardFailure();
 		}
 	};
 
@@ -142,10 +130,22 @@ export const useBoardSocketApi = () => {
 		emitOnSocket("update-board-visibility-request", payload);
 	};
 
-	const onFailure = (payload: ErrorActions["payload"]) => {
-		const { errorType = "notUpdated", boardObjectType = "board" } = payload;
-		notifySocketError(errorType, boardObjectType);
-	};
+	const createCardFailure = () => notifySocketError("notCreated", "boardCard");
+	const createColumnFailure = () =>
+		notifySocketError("notCreated", "boardColumn");
+	const deleteCardFailure = () => notifySocketError("notDeleted", "boardCard");
+	const deleteColumnFailure = () =>
+		notifySocketError("notDeleted", "boardColumn");
+	const fetchBoardFailure = () => notifySocketError("notLoaded", "board");
+	const moveCardFailure = () => notifySocketError("notUpdated", "boardCard");
+	const moveColumnFailure = () =>
+		notifySocketError("notUpdated", "boardColumn");
+	const updateColumnTitleFailure = () =>
+		notifySocketError("notUpdated", "boardColumn");
+	const updateBoardTitleFailure = () =>
+		notifySocketError("notUpdated", "board");
+	const updateBoardVisibilityFailure = () =>
+		notifySocketError("notUpdated", "board");
 
 	return {
 		dispatch,

--- a/src/modules/data/board/boardActions/boardSocketApi.composable.unit.ts
+++ b/src/modules/data/board/boardActions/boardSocketApi.composable.unit.ts
@@ -242,65 +242,49 @@ describe("useBoardSocketApi", () => {
 			it("should call notifySocketError for createCardFailure action", () => {
 				const { dispatch } = useBoardSocketApi();
 
-				const payload: CreateCardFailurePayload = {
-					errorType: "notUpdated",
-					boardObjectType: "boardCard",
-					requestPayload: { columnId: "test" },
-				};
+				const payload: CreateCardFailurePayload = { columnId: "test" };
 				dispatch(BoardActions.createCardFailure(payload));
 
 				expect(mockedErrorHandler.notifySocketError).toHaveBeenCalledWith(
-					payload.errorType,
-					payload.boardObjectType
+					"notCreated",
+					"boardCard"
 				);
 			});
 
 			it("should call notifySocketError for createColumnFailure action", () => {
 				const { dispatch } = useBoardSocketApi();
 
-				const payload: CreateColumnFailurePayload = {
-					errorType: "notUpdated",
-					boardObjectType: "boardColumn",
-					requestPayload: { boardId: "test" },
-				};
+				const payload: CreateColumnFailurePayload = { boardId: "test" };
 				dispatch(BoardActions.createColumnFailure(payload));
 
 				expect(mockedErrorHandler.notifySocketError).toHaveBeenCalledWith(
-					payload.errorType,
-					payload.boardObjectType
+					"notCreated",
+					"boardColumn"
 				);
 			});
 
 			it("should call notifySocketError for deleteCardFailure action", () => {
 				const { dispatch } = useBoardSocketApi();
 
-				const payload: DeleteCardFailurePayload = {
-					errorType: "notUpdated",
-					boardObjectType: "boardCard",
-					requestPayload: { cardId: "test" },
-				};
+				const payload: DeleteCardFailurePayload = { cardId: "test" };
 				dispatch(CardActions.deleteCardFailure(payload));
 
 				expect(mockedErrorHandler.notifySocketError).toHaveBeenCalledWith(
-					payload.errorType,
-					payload.boardObjectType
+					"notDeleted",
+					"boardCard"
 				);
 			});
 
 			it("should call notifySocketError for deleteColumnFailure action", () => {
 				const { dispatch } = useBoardSocketApi();
 
-				const payload: DeleteColumnFailurePayload = {
-					errorType: "notUpdated",
-					boardObjectType: "boardColumn",
-					requestPayload: { columnId: "test" },
-				};
+				const payload: DeleteColumnFailurePayload = { columnId: "test" };
 
 				dispatch(BoardActions.deleteColumnFailure(payload));
 
 				expect(mockedErrorHandler.notifySocketError).toHaveBeenCalledWith(
-					payload.errorType,
-					payload.boardObjectType
+					"notDeleted",
+					"boardColumn"
 				);
 			});
 
@@ -308,24 +292,20 @@ describe("useBoardSocketApi", () => {
 				const { dispatch } = useBoardSocketApi();
 
 				const payload: MoveCardFailurePayload = {
-					errorType: "notUpdated",
-					boardObjectType: "boardCard",
-					requestPayload: {
-						cardId: "test",
-						oldIndex: 0,
-						newIndex: 0,
-						fromColumnId: "fromColumnId",
-						fromColumnIndex: 0,
-						toColumnId: "toColumnId",
-						toColumnIndex: 0,
-					},
+					cardId: "test",
+					oldIndex: 0,
+					newIndex: 0,
+					fromColumnId: "fromColumnId",
+					fromColumnIndex: 0,
+					toColumnId: "toColumnId",
+					toColumnIndex: 0,
 				};
 
 				dispatch(BoardActions.moveCardFailure(payload));
 
 				expect(mockedErrorHandler.notifySocketError).toHaveBeenCalledWith(
-					payload.errorType,
-					payload.boardObjectType
+					"notUpdated",
+					"boardCard"
 				);
 			});
 
@@ -333,19 +313,15 @@ describe("useBoardSocketApi", () => {
 				const { dispatch } = useBoardSocketApi();
 
 				const payload: MoveColumnFailurePayload = {
-					errorType: "notUpdated",
-					boardObjectType: "boardColumn",
-					requestPayload: {
-						columnMove: { addedIndex: 1, columnId: "testColumnId" },
-						byKeyboard: false,
-					},
+					columnMove: { addedIndex: 1, columnId: "testColumnId" },
+					byKeyboard: false,
 				};
 
 				dispatch(BoardActions.moveColumnFailure(payload));
 
 				expect(mockedErrorHandler.notifySocketError).toHaveBeenCalledWith(
-					payload.errorType,
-					payload.boardObjectType
+					"notUpdated",
+					"boardColumn"
 				);
 			});
 
@@ -353,16 +329,15 @@ describe("useBoardSocketApi", () => {
 				const { dispatch } = useBoardSocketApi();
 
 				const payload: UpdateColumnTitleFailurePayload = {
-					errorType: "notUpdated",
-					boardObjectType: "boardColumn",
-					requestPayload: { columnId: "test", newTitle: "newTitle" },
+					columnId: "test",
+					newTitle: "newTitle",
 				};
 
 				dispatch(BoardActions.updateColumnTitleFailure(payload));
 
 				expect(mockedErrorHandler.notifySocketError).toHaveBeenCalledWith(
-					payload.errorType,
-					payload.boardObjectType
+					"notUpdated",
+					"boardColumn"
 				);
 			});
 
@@ -370,16 +345,15 @@ describe("useBoardSocketApi", () => {
 				const { dispatch } = useBoardSocketApi();
 
 				const payload: UpdateBoardTitleFailurePayload = {
-					errorType: "notUpdated",
-					boardObjectType: "boardColumn",
-					requestPayload: { boardId: "test", newTitle: "newTitle" },
+					boardId: "test",
+					newTitle: "newTitle",
 				};
 
 				dispatch(BoardActions.updateBoardTitleFailure(payload));
 
 				expect(mockedErrorHandler.notifySocketError).toHaveBeenCalledWith(
-					payload.errorType,
-					payload.boardObjectType
+					"notUpdated",
+					"board"
 				);
 			});
 
@@ -387,16 +361,15 @@ describe("useBoardSocketApi", () => {
 				const { dispatch } = useBoardSocketApi();
 
 				const payload: UpdateBoardVisibilityFailurePayload = {
-					errorType: "notUpdated",
-					boardObjectType: "board",
-					requestPayload: { boardId: "test", isVisible: true },
+					boardId: "test",
+					isVisible: true,
 				};
 
 				dispatch(BoardActions.updateBoardVisibilityFailure(payload));
 
 				expect(mockedErrorHandler.notifySocketError).toHaveBeenCalledWith(
-					payload.errorType,
-					payload.boardObjectType
+					"notUpdated",
+					"board"
 				);
 			});
 		});
@@ -518,7 +491,9 @@ describe("useBoardSocketApi", () => {
 
 			const { moveCardRequest } = useBoardSocketApi();
 
-			mockedSocketConnectionHandler.emitWithAck.mockRejectedValue({});
+			mockedSocketConnectionHandler.emitWithAck.mockRejectedValue({
+				type: "move-card-failure",
+			});
 
 			await moveCardRequest({
 				cardId: "cardId",

--- a/src/modules/data/board/cardActions/cardActionPayload.ts
+++ b/src/modules/data/board/cardActions/cardActionPayload.ts
@@ -1,9 +1,5 @@
 import { CardResponse, ContentElementType } from "@/serverApi/v3";
 
-import {
-	BoardObjectType,
-	ErrorType,
-} from "@/components/error-handling/ErrorHandler.composable";
 import { AnyContentElement } from "@/types/board/ContentElement";
 
 export type FetchCardRequestPayload = {
@@ -13,11 +9,7 @@ export type FetchCardSuccessPayload = {
 	cards: CardResponse[];
 	isOwnAction: boolean;
 };
-export type FetchCardFailurePayload = {
-	errorType: ErrorType;
-	boardObjectType: BoardObjectType;
-	requestPayload: FetchCardRequestPayload;
-};
+export type FetchCardFailurePayload = FetchCardRequestPayload;
 
 export type UpdateCardTitleRequestPayload = {
 	cardId: string;
@@ -28,11 +20,7 @@ export type UpdateCardTitleSuccessPayload = {
 	newTitle: string;
 	isOwnAction: boolean;
 };
-export type UpdateCardTitleFailurePayload = {
-	errorType: ErrorType;
-	boardObjectType: BoardObjectType;
-	requestPayload: UpdateCardTitleRequestPayload;
-};
+export type UpdateCardTitleFailurePayload = UpdateCardTitleRequestPayload;
 
 export type UpdateCardHeightRequestPayload = {
 	cardId: string;
@@ -43,11 +31,7 @@ export type UpdateCardHeightSuccessPayload = {
 	newHeight: number;
 	isOwnAction: boolean;
 };
-export type UpdateCardHeightFailurePayload = {
-	errorType: ErrorType;
-	boardObjectType: BoardObjectType;
-	requestPayload: UpdateCardHeightRequestPayload;
-};
+export type UpdateCardHeightFailurePayload = UpdateCardHeightRequestPayload;
 
 export type CreateElementRequestPayload = {
 	cardId: string;
@@ -61,11 +45,7 @@ export type CreateElementSuccessPayload = {
 	newElement: AnyContentElement;
 	isOwnAction: boolean;
 };
-export type CreateElementFailurePayload = {
-	errorType: ErrorType;
-	boardObjectType: BoardObjectType;
-	requestPayload: CreateElementRequestPayload;
-};
+export type CreateElementFailurePayload = CreateElementRequestPayload;
 
 export type DeleteElementRequestPayload = {
 	cardId: string;
@@ -76,11 +56,7 @@ export type DeleteElementSuccessPayload = {
 	elementId: string;
 	isOwnAction: boolean;
 };
-export type DeleteElementFailurePayload = {
-	errorType: ErrorType;
-	boardObjectType: BoardObjectType;
-	requestPayload: DeleteElementRequestPayload;
-};
+export type DeleteElementFailurePayload = DeleteElementRequestPayload;
 
 export type DeleteCardRequestPayload = {
 	cardId: string;
@@ -89,11 +65,7 @@ export type DeleteCardSuccessPayload = {
 	cardId: string;
 	isOwnAction: boolean;
 };
-export type DeleteCardFailurePayload = {
-	errorType: ErrorType;
-	boardObjectType: BoardObjectType;
-	requestPayload: DeleteCardRequestPayload;
-};
+export type DeleteCardFailurePayload = DeleteCardRequestPayload;
 
 export type MoveElementRequestPayload = {
 	elementId: string;
@@ -106,11 +78,7 @@ export type MoveElementSuccessPayload = {
 	toPosition: number;
 	isOwnAction: boolean;
 };
-export type MoveElementFailurePayload = {
-	errorType: ErrorType;
-	boardObjectType: BoardObjectType;
-	requestPayload: MoveElementRequestPayload;
-};
+export type MoveElementFailurePayload = MoveElementRequestPayload;
 
 export type UpdateElementRequestPayload = {
 	element: AnyContentElement;
@@ -123,10 +91,6 @@ export type UpdateElementSuccessPayload = {
 	};
 	isOwnAction: boolean;
 };
-export type UpdateElementFailurePayload = {
-	errorType: ErrorType;
-	boardObjectType: BoardObjectType;
-	requestPayload: UpdateElementRequestPayload;
-};
+export type UpdateElementFailurePayload = UpdateElementRequestPayload;
 
 export type DisconnectSocketRequestPayload = Record<string, never>;

--- a/src/modules/data/board/cardActions/cardSocketApi.composable.ts
+++ b/src/modules/data/board/cardActions/cardSocketApi.composable.ts
@@ -16,16 +16,6 @@ import {
 import { DisconnectSocketRequestPayload } from "../boardActions/boardActionPayload";
 import { useDebounceFn } from "@vueuse/core";
 
-type ErrorActions =
-	| ReturnType<typeof CardActions.createElementFailure>
-	| ReturnType<typeof CardActions.deleteCardFailure>
-	| ReturnType<typeof CardActions.deleteElementFailure>
-	| ReturnType<typeof CardActions.fetchCardFailure>
-	| ReturnType<typeof CardActions.moveElementFailure>
-	| ReturnType<typeof CardActions.updateCardHeightFailure>
-	| ReturnType<typeof CardActions.updateCardTitleFailure>
-	| ReturnType<typeof CardActions.updateElementFailure>;
-
 export const useCardSocketApi = () => {
 	const cardStore = useCardStore();
 
@@ -56,14 +46,14 @@ export const useCardSocketApi = () => {
 			),
 
 			// failure actions
-			on(CardActions.createElementFailure, onFailure),
-			on(CardActions.deleteElementFailure, onFailure),
-			on(CardActions.moveElementFailure, onFailure),
-			on(CardActions.updateElementFailure, onFailure),
-			on(CardActions.deleteCardFailure, onFailure),
-			on(CardActions.fetchCardFailure, onFailure),
-			on(CardActions.updateCardTitleFailure, onFailure),
-			on(CardActions.updateCardHeightFailure, onFailure)
+			on(CardActions.createElementFailure, createElementFailure),
+			on(CardActions.deleteElementFailure, deleteElementFailure),
+			on(CardActions.moveElementFailure, moveElementFailure),
+			on(CardActions.updateElementFailure, updateElementFailure),
+			on(CardActions.deleteCardFailure, deleteCardFailure),
+			on(CardActions.fetchCardFailure, fetchCardFailure),
+			on(CardActions.updateCardTitleFailure, updateCardTitleFailure),
+			on(CardActions.updateCardHeightFailure, updateCardHeightFailure)
 		);
 	};
 
@@ -124,10 +114,27 @@ export const useCardSocketApi = () => {
 		emitOnSocket("update-card-height-request", payload);
 	};
 
-	const onFailure = (payload: ErrorActions["payload"]) => {
-		const { errorType = "notUpdated", boardObjectType = "boardCard" } = payload;
-		notifySocketError(errorType, boardObjectType);
-	};
+	const createElementFailure = () =>
+		notifySocketError("notCreated", "boardElement");
+
+	const deleteElementFailure = () =>
+		notifySocketError("notDeleted", "boardElement");
+
+	const moveElementFailure = () =>
+		notifySocketError("notUpdated", "boardElement");
+
+	const updateElementFailure = () =>
+		notifySocketError("notUpdated", "boardElement");
+
+	const deleteCardFailure = () => notifySocketError("notDeleted", "boardCard");
+
+	const fetchCardFailure = () => notifySocketError("notLoaded", "boardCard");
+
+	const updateCardTitleFailure = () =>
+		notifySocketError("notUpdated", "boardCard");
+
+	const updateCardHeightFailure = () =>
+		notifySocketError("notUpdated", "boardCard");
 
 	return {
 		dispatch,

--- a/src/modules/data/board/cardActions/cardSocketApi.composable.unit.ts
+++ b/src/modules/data/board/cardActions/cardSocketApi.composable.unit.ts
@@ -219,18 +219,14 @@ describe("useCardSocketApi", () => {
 				const { dispatch } = useCardSocketApi();
 
 				const payload: CreateElementFailurePayload = {
-					errorType: "notCreated",
-					boardObjectType: "boardElement",
-					requestPayload: {
-						cardId: "cardId",
-						type: ContentElementType.RichText,
-					},
+					cardId: "cardId",
+					type: ContentElementType.RichText,
 				};
 				dispatch(CardActions.createElementFailure(payload));
 
 				expect(mockedErrorHandler.notifySocketError).toHaveBeenCalledWith(
-					payload.errorType,
-					payload.boardObjectType
+					"notCreated",
+					"boardElement"
 				);
 			});
 
@@ -238,18 +234,14 @@ describe("useCardSocketApi", () => {
 				const { dispatch } = useCardSocketApi();
 
 				const payload: DeleteElementFailurePayload = {
-					errorType: "notDeleted",
-					boardObjectType: "boardElement",
-					requestPayload: {
-						cardId: "cardId",
-						elementId: "elementId",
-					},
+					cardId: "cardId",
+					elementId: "elementId",
 				};
 				dispatch(CardActions.deleteElementFailure(payload));
 
 				expect(mockedErrorHandler.notifySocketError).toHaveBeenCalledWith(
-					payload.errorType,
-					payload.boardObjectType
+					"notDeleted",
+					"boardElement"
 				);
 			});
 
@@ -257,19 +249,15 @@ describe("useCardSocketApi", () => {
 				const { dispatch } = useCardSocketApi();
 
 				const payload: MoveElementFailurePayload = {
-					errorType: "notUpdated",
-					boardObjectType: "boardElement",
-					requestPayload: {
-						elementId: "elementId",
-						toCardId: "toCardId",
-						toPosition: 0,
-					},
+					elementId: "elementId",
+					toCardId: "toCardId",
+					toPosition: 0,
 				};
 				dispatch(CardActions.moveElementFailure(payload));
 
 				expect(mockedErrorHandler.notifySocketError).toHaveBeenCalledWith(
-					payload.errorType,
-					payload.boardObjectType
+					"notUpdated",
+					"boardElement"
 				);
 			});
 
@@ -277,17 +265,13 @@ describe("useCardSocketApi", () => {
 				const { dispatch } = useCardSocketApi();
 
 				const payload: UpdateElementFailurePayload = {
-					errorType: "notUpdated",
-					boardObjectType: "boardElement",
-					requestPayload: {
-						element: richTextElementResponseFactory.build(),
-					},
+					element: richTextElementResponseFactory.build(),
 				};
 				dispatch(CardActions.updateElementFailure(payload));
 
 				expect(mockedErrorHandler.notifySocketError).toHaveBeenCalledWith(
-					payload.errorType,
-					payload.boardObjectType
+					"notUpdated",
+					"boardElement"
 				);
 			});
 
@@ -295,11 +279,7 @@ describe("useCardSocketApi", () => {
 				const { dispatch } = useCardSocketApi();
 
 				const payload: DeleteCardFailurePayload = {
-					errorType: "notDeleted",
-					boardObjectType: "boardCard",
-					requestPayload: {
-						cardId: "cardId",
-					},
+					cardId: "cardId",
 				};
 				dispatch(CardActions.deleteCardFailure(payload));
 
@@ -313,17 +293,13 @@ describe("useCardSocketApi", () => {
 				const { dispatch } = useCardSocketApi();
 
 				const payload: FetchCardFailurePayload = {
-					errorType: "notLoaded",
-					boardObjectType: "boardCard",
-					requestPayload: {
-						cardIds: ["cardId"],
-					},
+					cardIds: ["cardId"],
 				};
 				dispatch(CardActions.fetchCardFailure(payload));
 
 				expect(mockedErrorHandler.notifySocketError).toHaveBeenCalledWith(
-					payload.errorType,
-					payload.boardObjectType
+					"notLoaded",
+					"boardCard"
 				);
 			});
 
@@ -331,18 +307,14 @@ describe("useCardSocketApi", () => {
 				const { dispatch } = useCardSocketApi();
 
 				const payload: UpdateCardTitleFailurePayload = {
-					errorType: "notUpdated",
-					boardObjectType: "boardCard",
-					requestPayload: {
-						cardId: "cardId",
-						newTitle: "newTitle",
-					},
+					cardId: "cardId",
+					newTitle: "newTitle",
 				};
 				dispatch(CardActions.updateCardTitleFailure(payload));
 
 				expect(mockedErrorHandler.notifySocketError).toHaveBeenCalledWith(
-					payload.errorType,
-					payload.boardObjectType
+					"notUpdated",
+					"boardCard"
 				);
 			});
 
@@ -350,18 +322,14 @@ describe("useCardSocketApi", () => {
 				const { dispatch } = useCardSocketApi();
 
 				const payload: UpdateCardHeightFailurePayload = {
-					errorType: "notUpdated",
-					boardObjectType: "boardCard",
-					requestPayload: {
-						cardId: "cardId",
-						newHeight: 100,
-					},
+					cardId: "cardId",
+					newHeight: 100,
 				};
 				dispatch(CardActions.updateCardHeightFailure(payload));
 
 				expect(mockedErrorHandler.notifySocketError).toHaveBeenCalledWith(
-					payload.errorType,
-					payload.boardObjectType
+					"notUpdated",
+					"boardCard"
 				);
 			});
 		});


### PR DESCRIPTION
# Short Description
Simplify all Failure-Action payloads to no longer carry ErrorType and BoardNodeType in order simplify failure-structure and to remove redundancy between action-name and carried data. This way refactorings on the backend-side are enabled

## Links to Ticket and related Pull-Requests
https://ticketsystem.dbildungscloud.de/browse/BC-7298
https://github.com/hpi-schul-cloud/schulcloud-server/pull/5041

## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
