### PR TITLE
BC-7313 - handle focus for create column action

### DIFF
--- a/src/modules/data/board/Board.store.ts
+++ b/src/modules/data/board/Board.store.ts
@@ -112,7 +112,13 @@ export const useBoardStore = defineStore("boardStore", () => {
 
 	const createColumnSuccess = (payload: CreateColumnSuccessPayload) => {
 		if (!board.value) return;
-		board.value.columns.push(payload.newColumn);
+		const { newColumn, isOwnAction } = payload;
+		board.value.columns.push(newColumn);
+
+		if (isOwnAction === true) {
+			useBoardFocusHandler().setFocus(newColumn.id);
+			setEditModeId(newColumn.id);
+		}
 	};
 
 	const deleteCardSuccess = (payload: DeleteCardSuccessPayload) => {

--- a/src/modules/data/board/boardActions/boardRestApi.composable.ts
+++ b/src/modules/data/board/boardActions/boardRestApi.composable.ts
@@ -2,7 +2,6 @@ import { useBoardStore } from "../Board.store";
 import { useBoardApi } from "../BoardApi.composable";
 import { useSharedEditMode } from "../EditMode.composable";
 import * as BoardActions from "./boardActions";
-import { useBoardFocusHandler } from "../BoardFocusHandler.composable";
 import {
 	BoardObjectType,
 	ErrorType,
@@ -75,9 +74,6 @@ export const useBoardRestApi = () => {
 
 		try {
 			const newColumn = await createColumnCall(boardStore.board?.id);
-			useBoardFocusHandler().setFocus(newColumn.id);
-			setEditModeId(newColumn.id);
-
 			boardStore.createColumnSuccess({ newColumn, isOwnAction: true });
 			return newColumn;
 		} catch (error) {


### PR DESCRIPTION
# Short Description
When several users with edit rights work on the same board and one creates a new column, this column should be in edit mode and the title be focused for this user but not for the other users. They should only see the new column appearing.

## Links to Ticket and related Pull-Requests
https://ticketsystem.dbildungscloud.de/browse/BC-7313

## Checklist before merging

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [ ] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
