### PR TITLE
BC-7822 - fix

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,15 +1,8 @@
 <template>
 	<v-app>
-		<Suspense>
-			<template #default>
-				<component :is="layout">
-					<router-view />
-				</component>
-			</template>
-			<template #fallback>
-				<p>Loading...</p>
-			</template>
-		</Suspense>
+		<component :is="layout">
+			<router-view />
+		</component>
 	</v-app>
 </template>
 

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -232,7 +232,7 @@ export const routes: Readonly<RouteRecordRaw[]> = [
 	},
 	{
 		path: `/rooms`,
-		component: async () => (await import("@page-room")).RoomsPage,
+		component: () => import("@/pages/rooms/CourseRoomOverview.page.vue"),
 		name: "rooms",
 	},
 	// TODO BC-7877 This redirect should be removed. Currently this route is used by the legacy client (and dof_app_deploy).


### PR DESCRIPTION
# Short Description
To avoid issues with the board page, the new rooms page will not be used for now.
Fix for https://github.com/hpi-schul-cloud/nuxt-client/pull/3355
<!-- Write a short explanation of what this Pull Request does -->

<!--
  This Pull-Request template helps the reviewers as well as servers as a checklist for you. Please feel out all possible sections.

  Quality guidelines:
    - Code should be self-explanatory; Document code that is not self-explanatory
    - Code respects SOLID principles, DRY, YAGNI, KISS
    - Think about potential bugs this Pull Request might introduce
    - Keep security in mind
    - Write tests (Unit and Integration), including for error cases. Don't decrease coverage
    - Business logic should be implemented in the API; never trust the client
    - UI changes should be discussed & agreed with the UX-Team before staring
    - Boyscout rule: leave the code in a better state than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Ticket and related Pull-Requests
BC-7822
<!--
Base links to copy
- https://ticketsystem.dbildungscloud.de/browse/BC-????
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://github.com/hpi-schul-cloud/end-to-end-tests/pull/????
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
-->

## Changes
- use old `App.vue` behavior
- link to course-overview instead of to new rooms page for rooms sidebar option
<!--
- What will the PR change?
- Why are the changes required?
- Links to documentation / tickets if exists, or provide more details here.
-->


## Checklist before merging

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [ ] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
