### PR TITLE
EW-1001 Updating server api

### DIFF
--- a/src/serverApi/v3/api.ts
+++ b/src/serverApi/v3/api.ts
@@ -7356,6 +7356,97 @@ export interface SingleColumnBoardResponse {
 /**
  * 
  * @export
+ * @interface SlimTaskResponse
+ */
+export interface SlimTaskResponse {
+    /**
+     * 
+     * @type {string}
+     * @memberof SlimTaskResponse
+     */
+    name: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof SlimTaskResponse
+     */
+    description: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof SlimTaskResponse
+     */
+    descriptionInputFormat: SlimTaskResponseDescriptionInputFormatEnum;
+    /**
+     * 
+     * @type {string}
+     * @memberof SlimTaskResponse
+     */
+    availableDate: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof SlimTaskResponse
+     */
+    dueDate: string | null;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof SlimTaskResponse
+     */
+    _private: boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof SlimTaskResponse
+     */
+    publicSubmissions: boolean | null;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof SlimTaskResponse
+     */
+    teamSubmissions: boolean | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof SlimTaskResponse
+     */
+    creator: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof SlimTaskResponse
+     */
+    courseId: string | null;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof SlimTaskResponse
+     */
+    submissionIds: Array<string>;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof SlimTaskResponse
+     */
+    finishedIds: Array<string>;
+}
+
+/**
+    * @export
+    * @enum {string}
+    */
+export enum SlimTaskResponseDescriptionInputFormatEnum {
+    PlainText = 'plainText',
+    RichTextCk5Simple = 'richTextCk5Simple',
+    RichTextCk4 = 'richTextCk4',
+    RichTextCk5 = 'richTextCk5'
+}
+
+/**
+ * 
+ * @export
  * @interface StudentPermissionParams
  */
 export interface StudentPermissionParams {
@@ -7690,86 +7781,80 @@ export interface TaskResponse {
      * @type {string}
      * @memberof TaskResponse
      */
+    id: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof TaskResponse
+     */
     name: string;
     /**
      * 
      * @type {string}
      * @memberof TaskResponse
      */
-    description: string;
+    availableDate?: string;
     /**
      * 
      * @type {string}
      * @memberof TaskResponse
      */
-    descriptionInputFormat: TaskResponseDescriptionInputFormatEnum;
+    dueDate?: string;
     /**
      * 
      * @type {string}
      * @memberof TaskResponse
      */
-    availableDate: string | null;
+    courseName: string;
     /**
      * 
      * @type {string}
      * @memberof TaskResponse
      */
-    dueDate: string | null;
+    lessonName?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof TaskResponse
+     */
+    courseId: string;
+    /**
+     * Task description object, with props content: string and type: input format types
+     * @type {RichText}
+     * @memberof TaskResponse
+     */
+    description?: RichText;
     /**
      * 
      * @type {boolean}
      * @memberof TaskResponse
      */
-    _private: boolean;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof TaskResponse
-     */
-    publicSubmissions: boolean | null;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof TaskResponse
-     */
-    teamSubmissions: boolean | null;
+    lessonHidden: boolean;
     /**
      * 
      * @type {string}
      * @memberof TaskResponse
      */
-    creator: string | null;
+    displayColor?: string;
     /**
      * 
      * @type {string}
      * @memberof TaskResponse
      */
-    courseId: string | null;
+    createdAt: string;
     /**
      * 
-     * @type {Array<string>}
+     * @type {string}
      * @memberof TaskResponse
      */
-    submissionIds: Array<string>;
+    updatedAt: string;
     /**
      * 
-     * @type {Array<string>}
+     * @type {TaskStatusResponse}
      * @memberof TaskResponse
      */
-    finishedIds: Array<string>;
+    status: TaskStatusResponse;
 }
-
-/**
-    * @export
-    * @enum {string}
-    */
-export enum TaskResponseDescriptionInputFormatEnum {
-    PlainText = 'plainText',
-    RichTextCk5Simple = 'richTextCk5Simple',
-    RichTextCk4 = 'richTextCk4',
-    RichTextCk5 = 'richTextCk5'
-}
-
 /**
  * 
  * @export
@@ -15591,7 +15676,7 @@ export const LessonApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async lessonControllerGetLessonTasks(lessonId: string, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<TaskResponse>>> {
+        async lessonControllerGetLessonTasks(lessonId: string, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<SlimTaskResponse>>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.lessonControllerGetLessonTasks(lessonId, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
@@ -15638,7 +15723,7 @@ export const LessonApiFactory = function (configuration?: Configuration, basePat
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        lessonControllerGetLessonTasks(lessonId: string, options?: any): AxiosPromise<Array<TaskResponse>> {
+        lessonControllerGetLessonTasks(lessonId: string, options?: any): AxiosPromise<Array<SlimTaskResponse>> {
             return localVarFp.lessonControllerGetLessonTasks(lessonId, options).then((request) => request(axios, basePath));
         },
     };
@@ -15684,7 +15769,7 @@ export interface LessonApiInterface {
      * @throws {RequiredError}
      * @memberof LessonApiInterface
      */
-    lessonControllerGetLessonTasks(lessonId: string, options?: any): AxiosPromise<Array<TaskResponse>>;
+    lessonControllerGetLessonTasks(lessonId: string, options?: any): AxiosPromise<Array<SlimTaskResponse>>;
 
 }
 

--- a/src/serverApi/v3/api.ts
+++ b/src/serverApi/v3/api.ts
@@ -3729,6 +3729,97 @@ export interface LessonCopyApiParams {
 /**
  * 
  * @export
+ * @interface LessonLinkedTaskResponse
+ */
+export interface LessonLinkedTaskResponse {
+    /**
+     * 
+     * @type {string}
+     * @memberof LessonLinkedTaskResponse
+     */
+    name: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof LessonLinkedTaskResponse
+     */
+    description: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof LessonLinkedTaskResponse
+     */
+    descriptionInputFormat: LessonLinkedTaskResponseDescriptionInputFormatEnum;
+    /**
+     * 
+     * @type {string}
+     * @memberof LessonLinkedTaskResponse
+     */
+    availableDate: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof LessonLinkedTaskResponse
+     */
+    dueDate: string | null;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof LessonLinkedTaskResponse
+     */
+    _private: boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof LessonLinkedTaskResponse
+     */
+    publicSubmissions: boolean | null;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof LessonLinkedTaskResponse
+     */
+    teamSubmissions: boolean | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof LessonLinkedTaskResponse
+     */
+    creator: string | null;
+    /**
+     * 
+     * @type {string}
+     * @memberof LessonLinkedTaskResponse
+     */
+    courseId: string | null;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof LessonLinkedTaskResponse
+     */
+    submissionIds: Array<string>;
+    /**
+     * 
+     * @type {Array<string>}
+     * @memberof LessonLinkedTaskResponse
+     */
+    finishedIds: Array<string>;
+}
+
+/**
+    * @export
+    * @enum {string}
+    */
+export enum LessonLinkedTaskResponseDescriptionInputFormatEnum {
+    PlainText = 'plainText',
+    RichTextCk5Simple = 'richTextCk5Simple',
+    RichTextCk4 = 'richTextCk4',
+    RichTextCk5 = 'richTextCk5'
+}
+
+/**
+ * 
+ * @export
  * @interface LessonMetadataListResponse
  */
 export interface LessonMetadataListResponse {
@@ -7353,97 +7444,6 @@ export interface SingleColumnBoardResponse {
      */
     isSynchronized: boolean;
 }
-/**
- * 
- * @export
- * @interface SlimTaskResponse
- */
-export interface SlimTaskResponse {
-    /**
-     * 
-     * @type {string}
-     * @memberof SlimTaskResponse
-     */
-    name: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof SlimTaskResponse
-     */
-    description: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof SlimTaskResponse
-     */
-    descriptionInputFormat: SlimTaskResponseDescriptionInputFormatEnum;
-    /**
-     * 
-     * @type {string}
-     * @memberof SlimTaskResponse
-     */
-    availableDate: string | null;
-    /**
-     * 
-     * @type {string}
-     * @memberof SlimTaskResponse
-     */
-    dueDate: string | null;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof SlimTaskResponse
-     */
-    _private: boolean;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof SlimTaskResponse
-     */
-    publicSubmissions: boolean | null;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof SlimTaskResponse
-     */
-    teamSubmissions: boolean | null;
-    /**
-     * 
-     * @type {string}
-     * @memberof SlimTaskResponse
-     */
-    creator: string | null;
-    /**
-     * 
-     * @type {string}
-     * @memberof SlimTaskResponse
-     */
-    courseId: string | null;
-    /**
-     * 
-     * @type {Array<string>}
-     * @memberof SlimTaskResponse
-     */
-    submissionIds: Array<string>;
-    /**
-     * 
-     * @type {Array<string>}
-     * @memberof SlimTaskResponse
-     */
-    finishedIds: Array<string>;
-}
-
-/**
-    * @export
-    * @enum {string}
-    */
-export enum SlimTaskResponseDescriptionInputFormatEnum {
-    PlainText = 'plainText',
-    RichTextCk5Simple = 'richTextCk5Simple',
-    RichTextCk4 = 'richTextCk4',
-    RichTextCk5 = 'richTextCk5'
-}
-
 /**
  * 
  * @export
@@ -15689,7 +15689,7 @@ export const LessonApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async lessonControllerGetLessonTasks(lessonId: string, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<SlimTaskResponse>>> {
+        async lessonControllerGetLessonTasks(lessonId: string, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<LessonLinkedTaskResponse>>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.lessonControllerGetLessonTasks(lessonId, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
@@ -15736,7 +15736,7 @@ export const LessonApiFactory = function (configuration?: Configuration, basePat
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        lessonControllerGetLessonTasks(lessonId: string, options?: any): AxiosPromise<Array<SlimTaskResponse>> {
+        lessonControllerGetLessonTasks(lessonId: string, options?: any): AxiosPromise<Array<LessonLinkedTaskResponse>> {
             return localVarFp.lessonControllerGetLessonTasks(lessonId, options).then((request) => request(axios, basePath));
         },
     };
@@ -15782,7 +15782,7 @@ export interface LessonApiInterface {
      * @throws {RequiredError}
      * @memberof LessonApiInterface
      */
-    lessonControllerGetLessonTasks(lessonId: string, options?: any): AxiosPromise<Array<SlimTaskResponse>>;
+    lessonControllerGetLessonTasks(lessonId: string, options?: any): AxiosPromise<Array<LessonLinkedTaskResponse>>;
 
 }
 

--- a/src/serverApi/v3/api.ts
+++ b/src/serverApi/v3/api.ts
@@ -7690,80 +7690,86 @@ export interface TaskResponse {
      * @type {string}
      * @memberof TaskResponse
      */
-    id: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof TaskResponse
-     */
     name: string;
     /**
      * 
      * @type {string}
      * @memberof TaskResponse
      */
-    availableDate?: string;
+    description: string;
     /**
      * 
      * @type {string}
      * @memberof TaskResponse
      */
-    dueDate?: string;
+    descriptionInputFormat: TaskResponseDescriptionInputFormatEnum;
     /**
      * 
      * @type {string}
      * @memberof TaskResponse
      */
-    courseName: string;
+    availableDate: string | null;
     /**
      * 
      * @type {string}
      * @memberof TaskResponse
      */
-    lessonName?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof TaskResponse
-     */
-    courseId: string;
-    /**
-     * Task description object, with props content: string and type: input format types
-     * @type {RichText}
-     * @memberof TaskResponse
-     */
-    description?: RichText;
+    dueDate: string | null;
     /**
      * 
      * @type {boolean}
      * @memberof TaskResponse
      */
-    lessonHidden: boolean;
+    _private: boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof TaskResponse
+     */
+    publicSubmissions: boolean | null;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof TaskResponse
+     */
+    teamSubmissions: boolean | null;
     /**
      * 
      * @type {string}
      * @memberof TaskResponse
      */
-    displayColor?: string;
+    creator: string | null;
     /**
      * 
      * @type {string}
      * @memberof TaskResponse
      */
-    createdAt: string;
+    courseId: string | null;
     /**
      * 
-     * @type {string}
+     * @type {Array<string>}
      * @memberof TaskResponse
      */
-    updatedAt: string;
+    submissionIds: Array<string>;
     /**
      * 
-     * @type {TaskStatusResponse}
+     * @type {Array<string>}
      * @memberof TaskResponse
      */
-    status: TaskStatusResponse;
+    finishedIds: Array<string>;
 }
+
+/**
+    * @export
+    * @enum {string}
+    */
+export enum TaskResponseDescriptionInputFormatEnum {
+    PlainText = 'plainText',
+    RichTextCk5Simple = 'richTextCk5Simple',
+    RichTextCk4 = 'richTextCk4',
+    RichTextCk5 = 'richTextCk5'
+}
+
 /**
  * 
  * @export
@@ -15502,6 +15508,43 @@ export const LessonApiAxiosParamCreator = function (configuration?: Configuratio
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * 
+         * @param {string} lessonId The id of the lesson.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        lessonControllerGetLessonTasks: async (lessonId: string, options: any = {}): Promise<RequestArgs> => {
+            // verify required parameter 'lessonId' is not null or undefined
+            assertParamExists('lessonControllerGetLessonTasks', 'lessonId', lessonId)
+            const localVarPath = `/lessons/{lessonId}/tasks`
+                .replace(`{${"lessonId"}}`, encodeURIComponent(String(lessonId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication bearer required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter, options.query);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
     }
 };
 
@@ -15542,6 +15585,16 @@ export const LessonApiFp = function(configuration?: Configuration) {
             const localVarAxiosArgs = await localVarAxiosParamCreator.lessonControllerGetLesson(lessonId, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
+        /**
+         * 
+         * @param {string} lessonId The id of the lesson.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async lessonControllerGetLessonTasks(lessonId: string, options?: any): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<Array<TaskResponse>>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.lessonControllerGetLessonTasks(lessonId, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
     }
 };
 
@@ -15579,6 +15632,15 @@ export const LessonApiFactory = function (configuration?: Configuration, basePat
         lessonControllerGetLesson(lessonId: string, options?: any): AxiosPromise<LessonResponse> {
             return localVarFp.lessonControllerGetLesson(lessonId, options).then((request) => request(axios, basePath));
         },
+        /**
+         * 
+         * @param {string} lessonId The id of the lesson.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        lessonControllerGetLessonTasks(lessonId: string, options?: any): AxiosPromise<Array<TaskResponse>> {
+            return localVarFp.lessonControllerGetLessonTasks(lessonId, options).then((request) => request(axios, basePath));
+        },
     };
 };
 
@@ -15614,6 +15676,15 @@ export interface LessonApiInterface {
      * @memberof LessonApiInterface
      */
     lessonControllerGetLesson(lessonId: string, options?: any): AxiosPromise<LessonResponse>;
+
+    /**
+     * 
+     * @param {string} lessonId The id of the lesson.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof LessonApiInterface
+     */
+    lessonControllerGetLessonTasks(lessonId: string, options?: any): AxiosPromise<Array<TaskResponse>>;
 
 }
 
@@ -15655,6 +15726,17 @@ export class LessonApi extends BaseAPI implements LessonApiInterface {
      */
     public lessonControllerGetLesson(lessonId: string, options?: any) {
         return LessonApiFp(this.configuration).lessonControllerGetLesson(lessonId, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @param {string} lessonId The id of the lesson.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof LessonApi
+     */
+    public lessonControllerGetLessonTasks(lessonId: string, options?: any) {
+        return LessonApiFp(this.configuration).lessonControllerGetLessonTasks(lessonId, options).then((request) => request(this.axios, this.basePath));
     }
 }
 


### PR DESCRIPTION
# Short Description
Updating the server API with `npm run generate-client:server`.

## Links to Ticket and related Pull-Requests
- <https://ticketsystem.dbildungscloud.de/browse/EW-1001>
- <https://github.com/hpi-schul-cloud/schulcloud-server/pull/5255>

## Checklist before merging
- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
