### PR TITLE
BC-8731 - Fix outline and contrast issue for boards as draft in rooms

### DIFF
--- a/src/modules/feature/room/BoardTile.vue
+++ b/src/modules/feature/room/BoardTile.vue
@@ -1,6 +1,6 @@
 <template>
 	<VCard
-		:class="isDraft ? 'opacity-70' : 'bg-surface-light'"
+		:class="isDraft ? 'opacity-80' : 'bg-surface-light'"
 		:variant="isDraft ? 'outlined' : 'flat'"
 		draggable="false"
 		:data-testid="`board-tile-${index}`"

--- a/src/styles/utility/_cards.scss
+++ b/src/styles/utility/_cards.scss
@@ -1,3 +1,3 @@
 .v-card--variant-outlined {
-	border-color: rgba(0, 0, 0, 0.12) !important;
+	border-color: rgba(var(--v-theme-on-surface), 0.25) 	!important;
 }


### PR DESCRIPTION
- fix color contrast issue for boards in draft status to 80% opacity
- darken outline of draft for better visibility
- delete outline in cards (board)
- adapt outline for elements