### PR TITLE
BC-8746 - fix add members

### DIFF
--- a/src/serverApi/v3/api.ts
+++ b/src/serverApi/v3/api.ts
@@ -8078,7 +8078,7 @@ export interface SchoolResponse {
      * @type {FederalStateResponse}
      * @memberof SchoolResponse
      */
-    federalState: FederalStateResponse;
+    federalState?: FederalStateResponse;
     /**
      * 
      * @type {CountyResponse}


### PR DESCRIPTION
# Short Description
Users are not able to add members to a room, if the database contains schools that have no federalState defined.

## Links to Tickets or other pull requests
BC-8746
https://github.com/hpi-schul-cloud/schulcloud-server/pull/5443

## Changes
* required property **federalState** for **schools** is now optional

## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
