### PR TITLE
BC-8885 - Video conference opening in new tab is blocked by specific browsers and devices

### DIFF
--- a/src/modules/feature/board-video-conference-element/components/VideoConferenceContentElement.vue
+++ b/src/modules/feature/board-video-conference-element/components/VideoConferenceContentElement.vue
@@ -256,6 +256,7 @@ const onStartVideoConference = async () => {
 	joinVideoConference().then((response: string | undefined) => {
 		if (response && windowReference) {
 			windowReference.location = response;
+			preFetchedUrl.value = response;
 		}
 	});
 	isConfigurationDialogOpen.value = false;

--- a/src/modules/feature/board-video-conference-element/components/VideoConferenceContentElement.vue
+++ b/src/modules/feature/board-video-conference-element/components/VideoConferenceContentElement.vue
@@ -217,7 +217,11 @@ const isCreating = computed(
 const boardParentType = computed(() => contextType.value);
 
 const onContentClick = async () => {
-	if (isRunning.value && preFetchedUrl && hasParticipationPermission.value) {
+	if (
+		isRunning.value &&
+		preFetchedUrl.value &&
+		hasParticipationPermission.value
+	) {
 		window.open(preFetchedUrl.value, "_blank");
 	} else if (!isRunning.value && canStart.value) {
 		isConfigurationDialogOpen.value = true;


### PR DESCRIPTION
# Short Description

When joining or starting a video conference in specific browsers or devices (e.g. iPad or Safari) the newly created tab is blocked and specifically on the iPad there is no hint about it.
<!-- Write a short explanation of what this Pull Request does -->

<!--
  This Pull-Request template helps the reviewers as well as servers as a checklist for you. Please feel out all possible sections.

  Quality guidelines:
    - Code should be self-explanatory; Document code that is not self-explanatory
    - Code respects SOLID principles, DRY, YAGNI, KISS
    - Think about potential bugs this Pull Request might introduce
    - Keep security in mind
    - Write tests (Unit and Integration), including for error cases. Don't decrease coverage
    - Business logic should be implemented in the API; never trust the client
    - UI changes should be discussed & agreed with the UX-Team before staring
    - Boyscout rule: leave the code in a better state than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Ticket and related Pull-Requests
BC-8885
<!--
Base links to copy
- https://ticketsystem.dbildungscloud.de/browse/BC-????
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://github.com/hpi-schul-cloud/end-to-end-tests/pull/????
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
-->

## Changes
- implementing pre fetching join url
<!--
- What will the PR change?
- Why are the changes required?
- Links to documentation / tickets if exists, or provide more details here.
-->

## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
