### PR TITLE
BC-9509 - Replace link to help article on Room Member Page

### DIFF
--- a/src/modules/page/room/RoomMembers.page.vue
+++ b/src/modules/page/room/RoomMembers.page.vue
@@ -23,7 +23,7 @@
 				scope="global"
 			>
 				<a
-					href="https://docs.dbildungscloud.de/display/SCDOK/Teameinladung+freigeben"
+					:href="informationLink"
 					target="_blank"
 					rel="noopener"
 					:ariaLabel="linkAriaLabel"
@@ -105,6 +105,7 @@ import {
 	ChangeRole,
 	useRoomAuthorization,
 } from "@feature-room";
+import { envConfigModule } from "@/store";
 import { ChangeRoomRoleBodyParamsRoleNameEnum, RoleName } from "@/serverApi/v3";
 import { useDisplay } from "vuetify";
 import { KebabMenu, KebabMenuActionLeaveRoom } from "@ui-kebab-menu";
@@ -263,5 +264,11 @@ const fabAction = computed(() => {
 const linkAriaLabel = computed(
 	() =>
 		`${t("pages.rooms.members.infoText.moreInformation")}, ${t("common.ariaLabel.newTab")}`
+);
+
+const informationLink = computed(() =>
+	envConfigModule.getEnv.ROOM_MEMBER_INFO_URL
+		? envConfigModule.getEnv.ROOM_MEMBER_INFO_URL
+		: "https://docs.dbildungscloud.de/display/SCDOK/Teameinladung+freigeben"
 );
 </script>

--- a/src/serverApi/v3/api.ts
+++ b/src/serverApi/v3/api.ts
@@ -1715,6 +1715,12 @@ export interface ConfigResponse {
      * @memberof ConfigResponse
      */
     LICENSE_SUMMARY_URL?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ConfigResponse
+     */
+    ROOM_MEMBER_INFO_URL: string | null;
 }
 /**
  * 

--- a/src/store/env-config-defaults.ts
+++ b/src/store/env-config-defaults.ts
@@ -77,4 +77,5 @@ export const defaultConfigEnvs: ConfigResponse = {
 	FEATURE_VIDIS_MEDIA_ACTIVATIONS_ENABLED: false,
 	FEATURE_COLUMN_BOARD_FILE_FOLDER_ENABLED: false,
 	LICENSE_SUMMARY_URL: "",
+	ROOM_MEMBER_INFO_URL: "",
 };


### PR DESCRIPTION
# Short Description
Currently the link behind "Further information" in the Room Member Administration page links to https://docs.dbildungscloud.de/display/SCDOK/Teameinladung+freigeben. This link needs to be replaced in all instances.

There is a different link for each instance, but it is the same for all languages.
<!-- Write a short explanation of what this Pull Request does -->

<!--
  This Pull-Request template helps the reviewers as well as servers as a checklist for you. Please feel out all possible sections.

  Quality guidelines:
    - Code should be self-explanatory; Document code that is not self-explanatory
    - Code respects SOLID principles, DRY, YAGNI, KISS
    - Think about potential bugs this Pull Request might introduce
    - Keep security in mind
    - Write tests (Unit and Integration), including for error cases. Don't decrease coverage
    - Business logic should be implemented in the API; never trust the client
    - UI changes should be discussed & agreed with the UX-Team before staring
    - Boyscout rule: leave the code in a better state than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Ticket and related Pull-Requests
BC-9509
https://github.com/hpi-schul-cloud/dof_app_deploy/pull/1152
https://github.com/hpi-schul-cloud/schulcloud-server/pull/5643

<!--
Base links to copy
- https://ticketsystem.dbildungscloud.de/browse/BC-????
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://github.com/hpi-schul-cloud/end-to-end-tests/pull/????
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
-->

## Changes
- implementing separate room member info page for each instance
<!--
- What will the PR change?
- Why are the changes required?
- Links to documentation / tickets if exists, or provide more details here.
-->

## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
