### PR TITLE
BC-9535 - Changed wording for Room Members Page

### DIFF
--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -1850,7 +1850,8 @@ export default {
 	"pages.rooms.members.changePermission": "Raumberechtigungen ändern",
 	"pages.rooms.members.changePermission.ariaLabel":
 		"Raumberechtigungen für {memberFullName} ändern",
-	"pages.rooms.members.manage": "Raum-Mitglieder",
+	"pages.rooms.members.manage": "Mitglieder verwalten",
+	"pages.rooms.members.view": "Mitglieder ansehen",
 	"pages.rooms.members.tab.members": "Mitglieder",
 	"pages.rooms.members.tab.invitations": "Einladungslinks",
 	"pages.rooms.members.tab.invitations.infoText":

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1818,7 +1818,8 @@ export default {
 	"pages.rooms.members.changePermission": "Change room permissions",
 	"pages.rooms.members.changePermission.ariaLabel":
 		"Change room permissions for {memberFullName}",
-	"pages.rooms.members.manage": "Room members",
+	"pages.rooms.members.manage": "Manage Members",
+	"pages.rooms.members.view": "View Members",
 	"pages.rooms.members.tab.members": "Members",
 	"pages.rooms.members.tab.invitations": "Invitations",
 	"pages.rooms.members.tab.invitations.infoText":

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -1872,7 +1872,8 @@ export default {
 		"Cambiar las autorizaciones en la sala",
 	"pages.rooms.members.changePermission.ariaLabel":
 		"Cambiar autorizaciones de sala para {memberFullName}",
-	"pages.rooms.members.manage": "Miembros de la sala",
+	"pages.rooms.members.manage": "Gestionar miembros",
+	"pages.rooms.members.view": "Ver miembros",
 	"pages.rooms.members.tab.members": "Miembros",
 	"pages.rooms.members.tab.invitations": "Invitaciones",
 	"pages.rooms.members.tab.invitations.infoText":

--- a/src/locales/uk.ts
+++ b/src/locales/uk.ts
@@ -1847,7 +1847,8 @@ export default {
 	"pages.rooms.members.changePermission": "Змінити дозволи кімнат",
 	"pages.rooms.members.changePermission.ariaLabel":
 		"Змінити дозвіл кімнат для {memberFullName}",
-	"pages.rooms.members.manage": "Учасник кімнати",
+	"pages.rooms.members.manage": "Керувати учасниками",
+	"pages.rooms.members.view": "Переглянути учасників",
 	"pages.rooms.members.tab.members": "Учасники",
 	"pages.rooms.members.tab.invitations": "Запрошення",
 	"pages.rooms.members.tab.invitations.infoText":

--- a/src/modules/feature/room/RoomMenu.vue
+++ b/src/modules/feature/room/RoomMenu.vue
@@ -7,6 +7,7 @@
 		<KebabMenuActionEdit v-if="canEditRoom" @click="() => $emit('room:edit')" />
 		<KebabMenuActionRoomMembers
 			v-if="canViewRoom"
+			:can-add-room-members="canAddRoomMembers"
 			@click="() => $emit('room:manage-members')"
 		/>
 		<KebabMenuActionDelete
@@ -50,5 +51,6 @@ const onDeleteRoom = async (confirmation: Promise<boolean>) => {
 	}
 };
 
-const { canEditRoom, canDeleteRoom, canViewRoom } = useRoomAuthorization();
+const { canAddRoomMembers, canEditRoom, canDeleteRoom, canViewRoom } =
+	useRoomAuthorization();
 </script>

--- a/src/modules/page/room/RoomMembers.page.unit.ts
+++ b/src/modules/page/room/RoomMembers.page.unit.ts
@@ -223,20 +223,43 @@ describe("RoomMembersPage", () => {
 		expect(roomDetailsStore.fetchRoom).toHaveBeenCalledWith(routeRoomId);
 	});
 
-	it("should set the page title", () => {
-		const { room } = setup();
+	describe("page title", () => {
+		it("should set correct title when isVisibleAddMemberButton is true", () => {
+			const { room } = setup({
+				isVisibleAddMemberButton: true,
+			});
 
-		expect(document.title).toContain(
-			`${room?.name} - pages.rooms.members.manage`
-		);
+			expect(document.title).toContain(
+				`${room?.name} - pages.rooms.members.manage`
+			);
+		});
+		it("should set correct title when isVisibleAddMemberButton is false", () => {
+			const { room } = setup({
+				isVisibleAddMemberButton: false,
+			});
+
+			expect(document.title).toContain(
+				`${room?.name} - pages.rooms.members.view`
+			);
+		});
 	});
 
-	it("should have the correct heading", async () => {
-		const { wrapper } = setup();
+	describe("heading", () => {
+		it("should set the correct heading when isVisibleAddMemberButton is true", () => {
+			const { wrapper } = setup({
+				isVisibleAddMemberButton: true,
+			});
+			const heading = wrapper.get("h1");
+			expect(heading.text()).toBe("pages.rooms.members.manage");
+		});
 
-		const heading = wrapper.get("h1");
-
-		expect(heading.text()).toBe("pages.rooms.members.manage");
+		it("should set the correct heading when isVisibleAddMemberButton is false", () => {
+			const { wrapper } = setup({
+				isVisibleAddMemberButton: false,
+			});
+			const heading = wrapper.get("h1");
+			expect(heading.text()).toBe("pages.rooms.members.view");
+		});
 	});
 
 	describe("onLeaveRoom", () => {
@@ -351,7 +374,13 @@ describe("RoomMembersPage", () => {
 	});
 
 	describe("DefaultWireframe", () => {
-		const buildBreadcrumbs = (room: RoomDetailsResponse) => {
+		const buildBreadcrumbs = (
+			room: RoomDetailsResponse,
+			isVisibleAddMemberButton: boolean
+		) => {
+			const membersBreadcrumb = isVisibleAddMemberButton
+				? "pages.rooms.members.manage"
+				: "pages.rooms.members.view";
 			return [
 				{
 					title: "pages.rooms.title",
@@ -362,7 +391,7 @@ describe("RoomMembersPage", () => {
 					to: `/rooms/${routeRoomId}`,
 				},
 				{
-					title: "pages.rooms.members.manage",
+					title: membersBreadcrumb,
 					disabled: true,
 				},
 			];
@@ -375,18 +404,37 @@ describe("RoomMembersPage", () => {
 			expect(wireframe.exists()).toBe(true);
 		});
 
-		it("should set the breadcrumbs and fab items", async () => {
-			const { wrapper, room } = setup();
+		it("should set fab items", async () => {
+			const { wrapper } = setup();
 			const wireframe = wrapper.findComponent(DefaultWireframe);
 
-			const expectedBreadcrumbs = buildBreadcrumbs(room!);
-
-			expect(wireframe.props("breadcrumbs")).toEqual(expectedBreadcrumbs);
 			expect(wireframe.props("fabItems")).toEqual({
 				icon: mdiPlus,
 				title: "pages.rooms.members.add",
 				ariaLabel: "pages.rooms.members.add",
 				dataTestId: "fab-add-members",
+			});
+		});
+
+		describe("breadcrumbs", () => {
+			it("should set correct breadcrumbs when isVisibleAddMemberButton is true", () => {
+				const { wrapper, room } = setup({
+					isVisibleAddMemberButton: true,
+				});
+				const wireframe = wrapper.findComponent(DefaultWireframe);
+				const expectedBreadcrumbs = buildBreadcrumbs(room!, true);
+
+				expect(wireframe.props("breadcrumbs")).toEqual(expectedBreadcrumbs);
+			});
+
+			it("should set correct breadcrumbs when isVisibleAddMemberButton is false", () => {
+				const { wrapper, room } = setup({
+					isVisibleAddMemberButton: false,
+				});
+				const wireframe = wrapper.findComponent(DefaultWireframe);
+				const expectedBreadcrumbs = buildBreadcrumbs(room!, false);
+
+				expect(wireframe.props("breadcrumbs")).toEqual(expectedBreadcrumbs);
 			});
 		});
 	});

--- a/src/modules/page/room/RoomMembers.page.vue
+++ b/src/modules/page/room/RoomMembers.page.vue
@@ -9,7 +9,7 @@
 			<div ref="header">
 				<div class="d-flex align-items-center">
 					<h1 class="text-h3 mb-4" data-testid="room-title">
-						{{ t("pages.rooms.members.manage") }}
+						{{ membersInfoText }}
 					</h1>
 					<KebabMenu class="mx-2" data-testid="room-member-menu">
 						<KebabMenuActionLeaveRoom @click="onLeaveRoom" />
@@ -132,11 +132,6 @@ const { currentUser } = storeToRefs(roomMembersStore);
 const { fetchMembers, getPotentialMembers, getSchools, leaveRoom, resetStore } =
 	roomMembersStore;
 
-const pageTitle = computed(() =>
-	buildPageTitle(`${room.value?.name} - ${t("pages.rooms.members.manage")}`)
-);
-useTitle(pageTitle);
-
 const header = ref<HTMLElement | null>(null);
 const { bottom: headerBottom } = useElementBounding(header);
 const { askConfirmation } = useConfirmationDialog();
@@ -144,6 +139,17 @@ const { canLeaveRoom } = useRoomAuthorization();
 const { isVisibleAddMemberButton, isVisibleTabNavigation } =
 	useRoomMemberVisibilityOptions(currentUser);
 const { FEATURE_ROOM_MEMBERS_TABS_ENABLED } = envConfigModule.getEnv;
+
+const membersInfoText = computed(() =>
+	isVisibleAddMemberButton.value
+		? t("pages.rooms.members.manage")
+		: t("pages.rooms.members.view")
+);
+
+const pageTitle = computed(() =>
+	buildPageTitle(`${room.value?.name} - ${membersInfoText.value}`)
+);
+useTitle(pageTitle);
 
 const activeTab = computed<Tab>({
 	get() {
@@ -244,7 +250,7 @@ const breadcrumbs: ComputedRef<Breadcrumb[]> = computed(() => {
 			to: `/rooms/${route.params.id}`,
 		},
 		{
-			title: t("pages.rooms.members.manage"),
+			title: membersInfoText.value,
 			disabled: true,
 		},
 	];

--- a/src/modules/ui/kebab-menu/KebabMenuActionRoomMembers.unit.ts
+++ b/src/modules/ui/kebab-menu/KebabMenuActionRoomMembers.unit.ts
@@ -1,0 +1,45 @@
+import {
+	createTestingI18n,
+	createTestingVuetify,
+} from "@@/tests/test-utils/setup";
+import { mount } from "@vue/test-utils";
+import { KebabMenuActionRoomMembers } from "@ui-kebab-menu";
+
+describe("KebabMenuActionRoomMembers", () => {
+	const setup = (canAddRoomMembers: boolean) => {
+		const wrapper = mount(KebabMenuActionRoomMembers, {
+			global: {
+				plugins: [createTestingVuetify(), createTestingI18n()],
+			},
+			props: {
+				canAddRoomMembers,
+			},
+		});
+
+		return {
+			wrapper,
+		};
+	};
+
+	describe("when the user can add room members", () => {
+		it("should show manage room members text", async () => {
+			const { wrapper } = setup(true);
+
+			const menuAction = wrapper.find(
+				"[data-testId=kebab-menu-action-room-members]"
+			);
+			expect(menuAction.text()).toBe("pages.rooms.members.manage");
+		});
+	});
+
+	describe("when the user can not add room members", () => {
+		it("should show view room members text", async () => {
+			const { wrapper } = setup(false);
+
+			const menuAction = wrapper.find(
+				"[data-testId=kebab-menu-action-room-members]"
+			);
+			expect(menuAction.text()).toBe("pages.rooms.members.view");
+		});
+	});
+});

--- a/src/modules/ui/kebab-menu/KebabMenuActionRoomMembers.vue
+++ b/src/modules/ui/kebab-menu/KebabMenuActionRoomMembers.vue
@@ -3,13 +3,24 @@
 		:icon="mdiAccountGroupOutline"
 		data-testid="kebab-menu-action-room-members"
 	>
-		{{ t("pages.rooms.members.manage") }}
+		{{ membersInfoText }}
 	</KebabMenuAction>
 </template>
 
 <script setup lang="ts">
 import KebabMenuAction from "./KebabMenuAction.vue";
 import { mdiAccountGroupOutline } from "@icons/material";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 const { t } = useI18n();
+
+const props = defineProps({
+	canAddRoomMembers: { type: Boolean, required: true, default: false },
+});
+
+const membersInfoText = computed(() =>
+	props.canAddRoomMembers
+		? t("pages.rooms.members.manage")
+		: t("pages.rooms.members.view")
+);
 </script>


### PR DESCRIPTION
# Short Description
After implementing the different tabs on the Room Members Page, we noticed that the wording on the page title should be changed for a better user experience. 
<!-- Write a short explanation of what this Pull Request does -->

<!--
  This Pull-Request template helps the reviewers as well as servers as a checklist for you. Please feel out all possible sections.

  Quality guidelines:
    - Code should be self-explanatory; Document code that is not self-explanatory
    - Code respects SOLID principles, DRY, YAGNI, KISS
    - Think about potential bugs this Pull Request might introduce
    - Keep security in mind
    - Write tests (Unit and Integration), including for error cases. Don't decrease coverage
    - Business logic should be implemented in the API; never trust the client
    - UI changes should be discussed & agreed with the UX-Team before staring
    - Boyscout rule: leave the code in a better state than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Ticket and related Pull-Requests
BC-9535
<!--
Base links to copy
- https://ticketsystem.dbildungscloud.de/browse/BC-????
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://github.com/hpi-schul-cloud/end-to-end-tests/pull/????
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
-->

## Changes
* adjusting wording on room members page according to room role
<!--
- What will the PR change?
- Why are the changes required?
- Links to documentation / tickets if exists, or provide more details here.
-->

## Screenshots of UI changes
<img width="300" alt="grafik" src="https://github.com/user-attachments/assets/945de91a-34a3-4b1b-98f0-813ae8ad23d6" /> <img width="300" alt="grafik" src="https://github.com/user-attachments/assets/c3fb809e-51d1-4359-9341-848da53367b8" />

<!--
- For UI changes, insert screenshots here.
- Has it been reviewed by a UX colleague?
-->

## Checklist before merging

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [ ] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
