### PR TITLE
BC-9531 - table controls are cut off

### DIFF
--- a/src/modules/feature/board-text-element/RichTextContentElement.vue
+++ b/src/modules/feature/board-text-element/RichTextContentElement.vue
@@ -94,6 +94,19 @@ const onKeyUp = () => ensurePoliteNotifications();
 		margin-bottom: var(--space-xs);
 	}
 
+	.ck .ck-widget.ck-widget_with-selection-handle > .ck-widget__type-around {
+		> .ck-widget__type-around__button_before {
+			top: 0.5rem;
+			left: 0.5rem;
+			margin-left: 0;
+		}
+
+		> .ck-widget__type-around__button_after {
+			bottom: 0.5rem;
+			right: 0.5rem;
+		}
+	}
+
 	.ck-content {
 		h4 {
 			font-family: var(--font-accent);
@@ -134,6 +147,11 @@ const onKeyUp = () => ensurePoliteNotifications();
 			overflow-x: auto;
 			overflow-y: hidden;
 			padding-right: 1px;
+		}
+
+		.ck-widget.ck-widget_with-selection-handle:hover
+			> .ck-widget__selection-handle {
+			display: none;
 		}
 
 		.math-tex {


### PR DESCRIPTION
# Short Description
When selecting a table the selection frame and controls are slightly cut off. 

## Links to Ticket and related Pull-Requests
https://ticketsystem.dbildungscloud.de/browse/BC-9531

## Changes
* position of buttons now inside the table

## Screenshots of UI changes

old
![image](https://github.com/user-attachments/assets/f5646c85-f2b4-4d13-972a-4f209cde7bff)


new
![image](https://github.com/user-attachments/assets/fc8e3647-0c89-4f24-bc0e-add9219bad96)


## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
