### PR TITLE
EW-1180: Close dialog before starting export.

### DIFF
--- a/src/components/molecules/CommonCartridgeExportModal.vue
+++ b/src/components/molecules/CommonCartridgeExportModal.vue
@@ -290,6 +290,7 @@ function onCloseDialog(): void {
 
 function closeDialog() {
 	emit("dialog-closed", false);
+	commonCartridgeExportModule.setIsExportModalOpen(false);
 }
 
 function resetDialog(): void {

--- a/src/components/molecules/CommonCartridgeExportModal.vue
+++ b/src/components/molecules/CommonCartridgeExportModal.vue
@@ -290,7 +290,7 @@ function onCloseDialog(): void {
 
 function closeDialog() {
 	emit("dialog-closed", false);
-	commonCartridgeExportModule.setIsExportModalOpen(false);
+	isExportModalOpen.value = false;
 }
 
 function resetDialog(): void {

--- a/src/components/molecules/CommonCartridgeExportModal.vue
+++ b/src/components/molecules/CommonCartridgeExportModal.vue
@@ -284,7 +284,15 @@ const someColumnBoardsSelected = computed(() => {
 });
 
 function onCloseDialog(): void {
+	closeDialog();
+	resetDialog();
+}
+
+function closeDialog() {
 	emit("dialog-closed", false);
+}
+
+function resetDialog(): void {
 	commonCartridgeExportModule.resetExportFlow();
 	step.value = 0;
 	allTasks.value.forEach((task) => {
@@ -325,8 +333,10 @@ async function onExport(): Promise<void> {
 	commonCartridgeExportModule.setTopics(topicIds);
 	commonCartridgeExportModule.setTasks(taskIds);
 	commonCartridgeExportModule.setColumnBoards(columnBoardIds);
+
+	closeDialog();
 	await commonCartridgeExportModule.startExport();
-	onCloseDialog();
+	resetDialog();
 }
 
 function onBack(): void {


### PR DESCRIPTION
# Short Description
Export dialog is now closed before export is started.

## Links to Ticket and related Pull-Requests
- https://ticketsystem.dbildungscloud.de/browse/EW-1180

## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
