### PR TITLE
BC-2344 - LDAP: Multiple class sources not possible

### DIFF
--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -1167,8 +1167,8 @@ export default {
 	"pages.administration.ldap.classes.path.info":
 		"Relativer Pfad vom Basis-Pfad",
 	"pages.administration.ldap.classes.path.subtitle":
-		"Hier musst du festlegen, wo wir Klassen finden und wie diese strukturiert sind. Durch das Hinzufügen von zwei Semikolons (;;) können mehrere Nutzerpfade getrennt voneinander hinterlegt werden.",
-	"pages.administration.ldap.classes.path.title": "Klassen-Pfad(e)",
+		"Hier musst du festlegen, wo wir Klassen finden und wie diese strukturiert sind.",
+	"pages.administration.ldap.classes.path.title": "Klassen-Pfad",
 	"pages.administration.ldap.classes.subtitle":
 		"Geben Sie das Klassenattribut an, in dem die folgenden Informationen in Ihrem LDAP verfügbar sind.",
 	"pages.administration.ldap.classes.title": "Klassen (optional)",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1161,8 +1161,8 @@ export default {
 		"Attribute participant",
 	"pages.administration.ldap.classes.path.info": "Relative path from base path",
 	"pages.administration.ldap.classes.path.subtitle":
-		"Here you need to define, where we find classes and how they are structured. By adding two semicolons (;;) you can add multiple user paths separately.",
-	"pages.administration.ldap.classes.path.title": "Class path(s)",
+		"Here you need to define, where we find classes and how they are structured.",
+	"pages.administration.ldap.classes.path.title": "Class path",
 	"pages.administration.ldap.classes.subtitle":
 		"Specify the class attribute where the following information is available in your LDAP.",
 	"pages.administration.ldap.classes.title": "Classes (optional)",

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -1199,7 +1199,7 @@ export default {
 	"pages.administration.ldap.classes.path.info":
 		"Ruta relativa desde la ruta base",
 	"pages.administration.ldap.classes.path.subtitle":
-		"Aquí hay que definir dónde encontramos las clases y cómo están estructuradas. Con la ayuda de dos puntos y coma (;;) tiene la posibilidad de almacenar varias rutas de usuari{'@'} por separado.",
+		"Aquí hay que definir dónde encontramos las clases y cómo están estructuradas.",
 	"pages.administration.ldap.classes.path.title": "Ruta de clase",
 	"pages.administration.ldap.classes.subtitle":
 		"Especifique el atributo de clase en el que está disponible la siguiente información en su LDAP.",

--- a/src/locales/uk.ts
+++ b/src/locales/uk.ts
@@ -1184,8 +1184,8 @@ export default {
 	"pages.administration.ldap.classes.path.info":
 		"Відносний шлях від базового шляху",
 	"pages.administration.ldap.classes.path.subtitle":
-		"Hier musst du festlegen, wo wir Klassen finden und wie diese strukturiert sind. Mit Hilfe von zwei Semikolons (;;) hast du die Möglichkeit, mehrere Nutzerpfade getrennt voneinander zu hinterlegen.",
-	"pages.administration.ldap.classes.path.title": "Шлях(и) класу",
+		"Тут ви повинні визначити, де ми знаходимо класи і як вони структуровані.",
+	"pages.administration.ldap.classes.path.title": "Шлях класу",
 	"pages.administration.ldap.classes.subtitle": "",
 	"pages.administration.ldap.classes.title": "",
 	"pages.administration.ldap.connection.basis.path.info":


### PR DESCRIPTION
# Short Description
On the LDAP config edit page, down below at "Klassen", the text states "Durch das Hinzufügen von zwei Semikolons können mehrere Nutzerpfade getrennt voneinander hinterlegt werden." but this doesn't seem to be correct.

<!-- Write a short explanation of what this Pull Request does -->

<!--
  This Pull-Request template helps the reviewers as well as servers as a checklist for you. Please feel out all possible sections.

  Quality guidelines:
    - Code should be self-explanatory; Document code that is not self-explanatory
    - Code respects SOLID principles, DRY, YAGNI, KISS
    - Think about potential bugs this Pull Request might introduce
    - Keep security in mind
    - Write tests (Unit and Integration), including for error cases. Don't decrease coverage
    - Business logic should be implemented in the API; never trust the client
    - UI changes should be discussed & agreed with the UX-Team before staring
    - Boyscout rule: leave the code in a better state than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Ticket and related Pull-Requests
BC-2344
<!--
Base links to copy
- https://ticketsystem.dbildungscloud.de/browse/BC-????
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://github.com/hpi-schul-cloud/end-to-end-tests/pull/????
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
-->

## Changes
- adjust config texts for ldap information regarding classes
<!--
- What will the PR change?
- Why are the changes required?
- Links to documentation / tickets if exists, or provide more details here.
-->

## Screenshots of UI changes
<img width="600" alt="grafik" src="https://github.com/user-attachments/assets/c8b800b1-7a43-480e-b0c6-4f84f08c1b35" />

<!--
- For UI changes, insert screenshots here.
- Has it been reviewed by a UX colleague?
-->

## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [x] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [x] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
