### PR TITLE
BC-9214 - File Name Overlap within VFileInput

### DIFF
--- a/src/components/molecules/CommonCartridgeImportModal.vue
+++ b/src/components/molecules/CommonCartridgeImportModal.vue
@@ -16,6 +16,7 @@
 			<v-card-text class="text--primary">
 				<v-file-input
 					v-model="file"
+					class="truncate-file-input"
 					:label="$t('pages.rooms.ccImportCourse.fileInputLabel')"
 					:prepend-icon="mdiTrayArrowUp"
 					accept=".imscc, .zip"
@@ -139,5 +140,13 @@ async function onConfirm(): Promise<void> {
 .button-section > button {
 	margin-left: calc(var(--space-base-vuetify) * 2);
 	margin-right: calc(var(--space-base-vuetify) * 2);
+}
+
+:deep(.truncate-file-input .v-field__input) {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	display: block;
+	max-width: 100%;
 }
 </style>

--- a/src/components/organisms/administration/GeneralSettings.vue
+++ b/src/components/organisms/administration/GeneralSettings.vue
@@ -89,7 +89,7 @@
 			<v-col>
 				<v-file-input
 					v-model="logoFile"
-					class="school-logo"
+					class="school-logo truncate-file-input"
 					:label="
 						$t(
 							'pages.administration.school.index.generalSettings.labels.uploadSchoolLogo'
@@ -330,5 +330,13 @@ export default {
 <style lang="scss" scoped>
 :deep(.v-list-item__prepend > .v-icon) {
 	opacity: 1;
+}
+
+:deep(.truncate-file-input .v-field__input) {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	display: block;
+	max-width: 100%;
 }
 </style>

--- a/src/components/organisms/administration/SchoolPolicyFormDialog.vue
+++ b/src/components/organisms/administration/SchoolPolicyFormDialog.vue
@@ -28,11 +28,10 @@
 				<v-file-input
 					ref="input-file"
 					v-model="file"
-					class="input-file mb-2"
+					class="input-file mb-2 truncate-file-input"
 					data-testid="input-file"
 					density="compact"
 					accept="application/pdf"
-					truncate-length="30"
 					:label="
 						t(
 							'pages.administration.school.index.schoolPolicy.labels.uploadFile'
@@ -195,5 +194,13 @@ export default defineComponent({
 
 .button-section > button {
 	margin-left: calc(var(--space-base-vuetify) * 2);
+}
+
+:deep(.truncate-file-input .v-field__input) {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	display: block;
+	max-width: 100%;
 }
 </style>

--- a/src/components/organisms/administration/SchoolTermsFormDialog.vue
+++ b/src/components/organisms/administration/SchoolTermsFormDialog.vue
@@ -28,12 +28,11 @@
 				<v-file-input
 					ref="input-file"
 					v-model="file"
-					class="input-file mb-2"
+					class="input-file mb-2 truncate-file-input"
 					data-testid="input-file"
 					:multiple="false"
 					density="compact"
 					accept="application/pdf"
-					truncate-length="30"
 					:label="
 						t('pages.administration.school.index.termsOfUse.labels.uploadFile')
 					"
@@ -192,5 +191,13 @@ export default defineComponent({
 
 .button-section > button {
 	margin-left: calc(var(--space-base-vuetify) * 2);
+}
+
+:deep(.truncate-file-input .v-field__input) {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	display: block;
+	max-width: 100%;
 }
 </style>


### PR DESCRIPTION
# Short Description
Long file names in the Data Protection/Usage Policy section (+ other areas) overlap with the "Remove" button during upload. -> Reason is the Upgrade vom Vuetify 2 -> 3
<!-- Write a short explanation of what this Pull Request does -->

<!--
  This Pull-Request template helps the reviewers as well as servers as a checklist for you. Please feel out all possible sections.

  Quality guidelines:
    - Code should be self-explanatory; Document code that is not self-explanatory
    - Code respects SOLID principles, DRY, YAGNI, KISS
    - Think about potential bugs this Pull Request might introduce
    - Keep security in mind
    - Write tests (Unit and Integration), including for error cases. Don't decrease coverage
    - Business logic should be implemented in the API; never trust the client
    - UI changes should be discussed & agreed with the UX-Team before staring
    - Boyscout rule: leave the code in a better state than you found it. Remove unnecessary lines. Listen to the linter.
-->

## Links to Ticket and related Pull-Requests
BC-9214
<!--
Base links to copy
- https://ticketsystem.dbildungscloud.de/browse/BC-????
- https://github.com/hpi-schul-cloud/schulcloud-server/pull/????
- https://github.com/hpi-schul-cloud/end-to-end-tests/pull/????
- https://github.com/hpi-schul-cloud/schulcloud-client/pull/????
-->

## Changes
- adjusting name truncation in VFileInput component for Vuetify 3
<!--
- What will the PR change?
- Why are the changes required?
- Links to documentation / tickets if exists, or provide more details here.
-->

## Screenshots of UI changes
<img width="422" alt="grafik" src="https://github.com/user-attachments/assets/773a71e5-04ed-43cc-b30e-b676091cf29f" />

<!--
- For UI changes, insert screenshots here.
- Has it been reviewed by a UX colleague?
-->

## Checklist before merging

- [ ] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [ ] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)
- [ ] Cypress: Every new feature has suitable Cypress tests implemented

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
