### PR TITLE
BC-9968 - Fix missing classes for text in boards

### DIFF
--- a/src/modules/feature/board-text-element/RichTextContentElement.unit.ts
+++ b/src/modules/feature/board-text-element/RichTextContentElement.unit.ts
@@ -99,11 +99,8 @@ describe("RichTextContentElement", () => {
 					isEditMode: false,
 					elementIndex: 0,
 				});
-				const displayComponent = wrapper.findComponent(
-					RichTextContentElementDisplayComponent
-				);
-
-				expect(displayComponent.classes()).toContain("first-element");
+				const parentDiv = wrapper.find("div");
+				expect(parentDiv.classes()).toContain("first-element");
 			});
 		});
 
@@ -114,11 +111,8 @@ describe("RichTextContentElement", () => {
 					isEditMode: false,
 					elementIndex: 1,
 				});
-				const displayComponent = wrapper.findComponent(
-					RichTextContentElementDisplayComponent
-				);
-
-				expect(displayComponent.classes()).not.toContain("first-element");
+				const parentDiv = wrapper.find("div");
+				expect(parentDiv.classes()).not.toContain("first-element");
 			});
 		});
 	});
@@ -143,11 +137,8 @@ describe("RichTextContentElement", () => {
 					isEditMode: true,
 					elementIndex: 0,
 				});
-				const editComponent = wrapper.findComponent(
-					RichTextContentElementEditComponent
-				);
-
-				expect(editComponent.classes()).toContain("first-element");
+				const parentDiv = wrapper.find("div");
+				expect(parentDiv.classes()).toContain("first-element");
 			});
 		});
 
@@ -158,10 +149,8 @@ describe("RichTextContentElement", () => {
 					isEditMode: true,
 					elementIndex: 1,
 				});
-				const editComponent = wrapper.findComponent(
-					RichTextContentElementEditComponent
-				);
-				expect(editComponent.classes()).not.toContain("first-element");
+				const parentDiv = wrapper.find("div");
+				expect(parentDiv.classes()).not.toContain("first-element");
 			});
 		});
 

--- a/src/modules/feature/board-text-element/RichTextContentElement.vue
+++ b/src/modules/feature/board-text-element/RichTextContentElement.vue
@@ -1,15 +1,13 @@
 <template>
-	<div>
+	<div :class="{ 'first-element': isFirstElement }">
 		<RichTextContentElementDisplay
 			v-if="!isEditMode"
-			:class="{ 'first-element': isFirstElement }"
 			:data-testid="`rich-text-display-${columnIndex}-${elementIndex}`"
 			:value="element.content.text"
 		/>
 		<RichTextContentElementEdit
 			v-if="isEditMode"
 			:autofocus="autofocus"
-			:class="{ 'first-element': isFirstElement }"
 			:value="modelValue.text"
 			:data-testid="`rich-text-edit-${columnIndex}-${elementIndex}`"
 			:column-index="columnIndex"
@@ -146,7 +144,7 @@ const isFirstElement = computed(() => props.elementIndex === 0);
 	}
 }
 
-.first-element > :is(h4, h5):first-child {
+.first-element :is(h4, h5):first-child {
 	margin-top: 0;
 }
 </style>


### PR DESCRIPTION
# Short Description

After switching position (move up/down) of elements (e.g.tool and text) some ck-classes are missing, therefore different text styles are not displayed correctly e.g. headings.

## Links to Ticket and related Pull-Requests
https://ticketsystem.dbildungscloud.de/browse/BC-9968

## Changes
move first-class logic to parent div
old
![image](https://github.com/user-attachments/assets/eaa7e4ea-bbe2-4c6c-a26f-8231fd5d3a3a)
new
![image](https://github.com/user-attachments/assets/b3e3f4d4-e127-4c37-be57-9eae67677119)


## Checklist before merging

- [x] QA: In addition to review, the code has been manually tested (if manual testing is possible)
- [ ] PO: Any deviation from requirements was agreed with Product-Owner / ticket author / support-team
- [ ] DEV: Every new component is implemented having accessibility in mind (e.g. aria-label, role property)
- [ ] Cypress: Every new feature has suitable Cypress tests implemented

> Notice: Please keep this Pull-Request as a Draft (or add WIP label), until it is ready to be reviewed
